### PR TITLE
fix(ai-43): add recursion depth limit to callOpenAICompatible

### DIFF
--- a/apps/fiona-slack/src/agent/interaction-telemetry.js
+++ b/apps/fiona-slack/src/agent/interaction-telemetry.js
@@ -4,7 +4,12 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import { recordInteraction } from './interaction-store.js';
-import { handleMetadataTimeout, MetadataLifecycleState } from './llm-caller.js';
+import {
+  handleMetadataTimeout,
+  MetadataLifecycleState,
+  TOOL_CALL_DEPTH_EXCEEDED_CODE,
+  TOOL_CALL_DEPTH_EXCEEDED_MESSAGE,
+} from './llm-caller.js';
 import { rollbackFinalization } from './utils/idempotent-finalize.js';
 
 export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -100,12 +105,18 @@ export async function handleInteractionWithTelemetry(
       errorType = 'llm_rate_limited';
     } else if (e.code?.includes('openai') || e.name?.includes('APIError')) {
       errorType = 'llm_error';
+    } else if (e.code === TOOL_CALL_DEPTH_EXCEEDED_CODE) {
+      errorType = 'max_tool_call_depth_exceeded';
     } else {
       errorType = 'unknown';
     }
 
     logger.error('Failed to handle a user message event:', e);
-    await say(':warning: Something went wrong! Please try again later.').catch(() => {
+    const userErrorMessage =
+      e.code === TOOL_CALL_DEPTH_EXCEEDED_CODE
+        ? `:warning: ${TOOL_CALL_DEPTH_EXCEEDED_MESSAGE}`
+        : ':warning: Something went wrong! Please try again later.';
+    await say(userErrorMessage).catch(() => {
       logger.warn?.('Failed to send error message to Slack');
     });
   } finally {

--- a/apps/fiona-slack/src/agent/llm-caller.js
+++ b/apps/fiona-slack/src/agent/llm-caller.js
@@ -39,6 +39,7 @@ const PERPLEXITY_DOMAIN_FILTER = process.env.PERPLEXITY_DOMAIN_FILTER
 
 // ─── Citation Density Policy ────────────────────────────────────────────────
 export const METADATA_CONTRACT_VERSION = 'v1';
+export const MAX_RECURSION_DEPTH = 10;
 
 /**
  * Safely parse an environment variable into a positive integer.
@@ -614,7 +615,10 @@ async function callAzureAgent(streamer, prompts, logger) {
  * @param {Array} prompts
  * @param {import("@slack/logger").Logger} logger
  */
-async function callOpenAICompatible(streamer, prompts, logger) {
+async function callOpenAICompatible(streamer, prompts, logger, depth = 0) {
+  if (depth >= MAX_RECURSION_DEPTH) {
+    throw new Error(`Maximum recursion depth (${MAX_RECURSION_DEPTH}) exceeded in callOpenAICompatible`);
+  }
   const toolCalls = [];
   const appender = createCitationAwareAppender(streamer);
 
@@ -719,7 +723,7 @@ async function callOpenAICompatible(streamer, prompts, logger) {
       }
     }
 
-    await callOpenAICompatible(streamer, prompts, logger);
+    await callOpenAICompatible(streamer, prompts, logger, depth + 1);
   }
 }
 

--- a/apps/fiona-slack/src/agent/llm-caller.js
+++ b/apps/fiona-slack/src/agent/llm-caller.js
@@ -39,7 +39,6 @@ const PERPLEXITY_DOMAIN_FILTER = process.env.PERPLEXITY_DOMAIN_FILTER
 
 // ─── Citation Density Policy ────────────────────────────────────────────────
 export const METADATA_CONTRACT_VERSION = 'v1';
-export const MAX_RECURSION_DEPTH = 10;
 
 /**
  * Safely parse an environment variable into a positive integer.
@@ -57,6 +56,13 @@ function parsePositiveIntEnv(rawValue, defaultValue) {
   }
   return parsedInt;
 }
+
+// ─── Tool Call Recursion Limits ─────────────────────────────────────────────
+export const MAX_TOOL_CALL_DEPTH = parsePositiveIntEnv(process.env.MAX_TOOL_CALL_DEPTH, 10);
+export const MAX_RECURSION_DEPTH = MAX_TOOL_CALL_DEPTH;
+export const TOOL_CALL_DEPTH_EXCEEDED_CODE = 'MAX_TOOL_CALL_DEPTH_EXCEEDED';
+export const TOOL_CALL_DEPTH_EXCEEDED_MESSAGE =
+  'The AI encountered too many tool invocations. Please try a simpler request.';
 
 export const CITATION_POLICY = {
   MAX_SOURCES_DISPLAYED: parsePositiveIntEnv(process.env.CITATION_MAX_SOURCES, 10),
@@ -616,8 +622,23 @@ async function callAzureAgent(streamer, prompts, logger) {
  * @param {import("@slack/logger").Logger} logger
  */
 async function callOpenAICompatible(streamer, prompts, logger, depth = 0) {
-  if (depth >= MAX_RECURSION_DEPTH) {
-    throw new Error(`Maximum recursion depth (${MAX_RECURSION_DEPTH}) exceeded in callOpenAICompatible`);
+  if (depth >= MAX_TOOL_CALL_DEPTH) {
+    const recentToolCalls = prompts
+      .filter((prompt) => prompt?.type === 'function_call' && typeof prompt.name === 'string')
+      .slice(-5)
+      .map((prompt) => prompt.name);
+    logger.warn('[llm] Maximum tool call depth exceeded.', {
+      code: TOOL_CALL_DEPTH_EXCEEDED_CODE,
+      depth,
+      maxDepth: MAX_TOOL_CALL_DEPTH,
+      recentToolCalls,
+    });
+
+    const error = new Error(`Maximum tool call depth (${MAX_TOOL_CALL_DEPTH}) exceeded`);
+    error.name = 'ToolCallDepthError';
+    error.code = TOOL_CALL_DEPTH_EXCEEDED_CODE;
+    error.userMessage = TOOL_CALL_DEPTH_EXCEEDED_MESSAGE;
+    throw error;
   }
   const toolCalls = [];
   const appender = createCitationAwareAppender(streamer);

--- a/apps/fiona-slack/tests/agent/interaction-telemetry.test.js
+++ b/apps/fiona-slack/tests/agent/interaction-telemetry.test.js
@@ -3,7 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 jest.unstable_mockModule('../../src/agent/interaction-store.js', () => ({
   recordInteraction: jest.fn().mockResolvedValue(undefined),
@@ -15,6 +15,8 @@ jest.unstable_mockModule('../../src/agent/utils/idempotent-finalize.js', () => (
 
 jest.unstable_mockModule('../../src/agent/llm-caller.js', () => ({
   handleMetadataTimeout: jest.fn(),
+  TOOL_CALL_DEPTH_EXCEEDED_CODE: 'MAX_TOOL_CALL_DEPTH_EXCEEDED',
+  TOOL_CALL_DEPTH_EXCEEDED_MESSAGE: 'The AI encountered too many tool invocations. Please try a simpler request.',
   MetadataLifecycleState: {
     READY_TO_FINALIZE: 'READY_TO_FINALIZE',
     DEGRADED_NO_METADATA: 'DEGRADED_NO_METADATA',
@@ -438,9 +440,7 @@ describe('handleInteractionWithTelemetry', () => {
         ),
       ).resolves.not.toThrow();
 
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to record interaction'),
-      );
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to record interaction'));
     });
 
     it('includes rate limit flag in recorded interaction', async () => {

--- a/apps/fiona-slack/tests/agent/interaction-telemetry.test.js
+++ b/apps/fiona-slack/tests/agent/interaction-telemetry.test.js
@@ -29,7 +29,12 @@ const { handleInteractionWithTelemetry, sleep, waitForMetadataReady } = await im
 );
 const { recordInteraction } = await import('../../src/agent/interaction-store.js');
 const { rollbackFinalization } = await import('../../src/agent/utils/idempotent-finalize.js');
-const { handleMetadataTimeout, MetadataLifecycleState } = await import('../../src/agent/llm-caller.js');
+const {
+  handleMetadataTimeout,
+  MetadataLifecycleState,
+  TOOL_CALL_DEPTH_EXCEEDED_CODE,
+  TOOL_CALL_DEPTH_EXCEEDED_MESSAGE,
+} = await import('../../src/agent/llm-caller.js');
 
 describe('handleInteractionWithTelemetry', () => {
   let say;
@@ -276,6 +281,34 @@ describe('handleInteractionWithTelemetry', () => {
           errorType: 'llm_error',
         }),
       );
+    });
+
+    it('classifies max tool call depth errors and sends a targeted user message', async () => {
+      const error = new Error('Maximum tool call depth exceeded');
+      error.code = TOOL_CALL_DEPTH_EXCEEDED_CODE;
+      const handler = jest.fn().mockRejectedValue(error);
+
+      await handleInteractionWithTelemetry(
+        {
+          userId: 'U123',
+          teamId: 'T123',
+          channelId: 'C123',
+          threadTs: '1712345678.001',
+          messageTs: '1712345678.123',
+          interactionType: 'app_mention',
+          logger,
+          say,
+        },
+        handler,
+      );
+
+      expect(recordInteraction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          errorType: 'max_tool_call_depth_exceeded',
+        }),
+      );
+      expect(say).toHaveBeenCalledWith(`:warning: ${TOOL_CALL_DEPTH_EXCEEDED_MESSAGE}`);
     });
 
     it('classifies unknown errors as unknown', async () => {

--- a/apps/fiona-slack/tests/agent/llm-caller.recursion.test.js
+++ b/apps/fiona-slack/tests/agent/llm-caller.recursion.test.js
@@ -3,21 +3,93 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import { describe, it, expect, beforeAll } from '@jest/globals';
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const createMock = jest.fn();
+
+jest.unstable_mockModule('@azure/ai-projects', () => ({
+  AIProjectClient: jest.fn(),
+}));
+
+jest.unstable_mockModule('@azure/identity', () => ({
+  DefaultAzureCredential: jest.fn(),
+}));
+
+jest.unstable_mockModule('openai', () => ({
+  OpenAI: jest.fn().mockImplementation(() => ({
+    responses: { create: createMock },
+  })),
+  AzureOpenAI: jest.fn().mockImplementation(() => ({
+    responses: { create: createMock },
+  })),
+}));
+
+jest.unstable_mockModule('../../src/agent/utils/citation-telemetry.js', () => ({
+  recordMetadataWaitDuration: jest.fn(),
+  recordSourceCount: jest.fn(),
+  incrementDegradedNoMetadataCount: jest.fn(),
+  incrementTotalResponseCount: jest.fn(),
+}));
 
 describe('callOpenAICompatible recursion depth', () => {
+  let callLLM;
   let MAX_RECURSION_DEPTH;
+  let TOOL_CALL_DEPTH_EXCEEDED_CODE;
+  let TOOL_CALL_DEPTH_EXCEEDED_MESSAGE;
 
   beforeAll(async () => {
-    // Set dummy env vars so llm-caller.js module-level client init doesn't throw
     process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || 'test-key';
     process.env.AZURE_OPENAI_API_KEY = process.env.AZURE_OPENAI_API_KEY || 'test-key';
-    ({ MAX_RECURSION_DEPTH } = await import('../../src/agent/llm-caller.js'));
+    ({ callLLM, MAX_RECURSION_DEPTH, TOOL_CALL_DEPTH_EXCEEDED_CODE, TOOL_CALL_DEPTH_EXCEEDED_MESSAGE } = await import(
+      '../../src/agent/llm-caller.js'
+    ));
+  });
+
+  beforeEach(() => {
+    createMock.mockReset();
   });
 
   it('exports MAX_RECURSION_DEPTH as a positive number no greater than 20', () => {
     expect(typeof MAX_RECURSION_DEPTH).toBe('number');
     expect(MAX_RECURSION_DEPTH).toBeGreaterThan(0);
     expect(MAX_RECURSION_DEPTH).toBeLessThanOrEqual(20);
+  });
+
+  it('throws a typed error when tool-call recursion exceeds the maximum depth', async () => {
+    createMock.mockImplementation(() =>
+      (async function* streamWithToolCall() {
+        yield {
+          type: 'response.output_item.done',
+          item: {
+            type: 'function_call',
+            name: 'roll_dice',
+            id: 'fc_1',
+            call_id: 'call_1',
+            arguments: '{"count":1,"sides":6}',
+          },
+        };
+      })(),
+    );
+
+    const streamer = {
+      append: jest.fn().mockResolvedValue(undefined),
+      __citation_metadata: null,
+    };
+    const logger = { warn: jest.fn(), error: jest.fn(), info: jest.fn() };
+    const prompts = [{ role: 'user', content: 'roll a die forever' }];
+
+    await expect(callLLM(streamer, prompts, logger)).rejects.toMatchObject({
+      name: 'ToolCallDepthError',
+      code: TOOL_CALL_DEPTH_EXCEEDED_CODE,
+      userMessage: TOOL_CALL_DEPTH_EXCEEDED_MESSAGE,
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[llm] Maximum tool call depth exceeded.',
+      expect.objectContaining({
+        code: TOOL_CALL_DEPTH_EXCEEDED_CODE,
+        maxDepth: MAX_RECURSION_DEPTH,
+      }),
+    );
   });
 });

--- a/apps/fiona-slack/tests/agent/llm-caller.recursion.test.js
+++ b/apps/fiona-slack/tests/agent/llm-caller.recursion.test.js
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { describe, it, expect, beforeAll } from '@jest/globals';
+
+describe('callOpenAICompatible recursion depth', () => {
+  let MAX_RECURSION_DEPTH;
+
+  beforeAll(async () => {
+    // Set dummy env vars so llm-caller.js module-level client init doesn't throw
+    process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || 'test-key';
+    process.env.AZURE_OPENAI_API_KEY = process.env.AZURE_OPENAI_API_KEY || 'test-key';
+    ({ MAX_RECURSION_DEPTH } = await import('../../src/agent/llm-caller.js'));
+  });
+
+  it('exports MAX_RECURSION_DEPTH as a positive number no greater than 20', () => {
+    expect(typeof MAX_RECURSION_DEPTH).toBe('number');
+    expect(MAX_RECURSION_DEPTH).toBeGreaterThan(0);
+    expect(MAX_RECURSION_DEPTH).toBeLessThanOrEqual(20);
+  });
+});

--- a/apps/fiona-slack/tests/listeners/assistant/message.test.js
+++ b/apps/fiona-slack/tests/listeners/assistant/message.test.js
@@ -3,7 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 // Mock the LLM caller and rate limiter before importing the module under test
 jest.unstable_mockModule('../../../src/agent/interaction-store.js', () => ({
@@ -27,6 +27,8 @@ jest.unstable_mockModule('../../../src/agent/llm-caller.js', () => ({
     FINALIZED: 'finalized',
     DEGRADED_NO_METADATA: 'degraded_no_metadata',
   },
+  TOOL_CALL_DEPTH_EXCEEDED_CODE: 'MAX_TOOL_CALL_DEPTH_EXCEEDED',
+  TOOL_CALL_DEPTH_EXCEEDED_MESSAGE: 'The AI encountered too many tool invocations. Please try a simpler request.',
 }));
 
 jest.unstable_mockModule('../../../src/agent/rate-limiter.js', () => ({
@@ -35,9 +37,11 @@ jest.unstable_mockModule('../../../src/agent/rate-limiter.js', () => ({
 
 // Simulate the real fallback behaviour: when history is empty, return [currentText as user message].
 jest.unstable_mockModule('../../../src/agent/thread-history.js', () => ({
-  buildThreadHistory: jest.fn().mockImplementation((_client, _channel, _ts, { currentText = null } = {}) =>
-    Promise.resolve(currentText ? [{ role: 'user', content: currentText }] : []),
-  ),
+  buildThreadHistory: jest
+    .fn()
+    .mockImplementation((_client, _channel, _ts, { currentText = null } = {}) =>
+      Promise.resolve(currentText ? [{ role: 'user', content: currentText }] : []),
+    ),
 }));
 
 jest.unstable_mockModule('../../../src/agent/utils/idempotent-finalize.js', () => ({
@@ -45,7 +49,6 @@ jest.unstable_mockModule('../../../src/agent/utils/idempotent-finalize.js', () =
   shouldFinalize: jest.fn().mockReturnValue(true),
   rollbackFinalization: jest.fn(),
 }));
-
 
 const { message: messageHandler } = await import('../../../src/listeners/assistant/message.js');
 const { callLLM, finalizeMetadataEnvelope } = await import('../../../src/agent/llm-caller.js');
@@ -231,12 +234,14 @@ describe('message (assistant thread handler)', () => {
     });
 
     expect(recordInteraction).toHaveBeenCalledTimes(1);
-    expect(recordInteraction).toHaveBeenCalledWith(expect.objectContaining({
-      userId: 'U123',
-      rateLimited: true,
-      status: 'error',
-      errorType: 'rate_limited',
-    }));
+    expect(recordInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'U123',
+        rateLimited: true,
+        status: 'error',
+        errorType: 'rate_limited',
+      }),
+    );
 
     expect(mockSay).toHaveBeenCalledTimes(1);
     const [msg] = mockSay.mock.calls[0];
@@ -355,102 +360,102 @@ describe('message (assistant thread handler)', () => {
   });
 
   it('skips streamer.stop when shouldFinalize returns false', async () => {
-      shouldFinalize.mockReturnValueOnce(false);
+    shouldFinalize.mockReturnValueOnce(false);
 
-      await messageHandler({
-        client: mockClient,
-        context: mockContext,
-        logger: mockLogger,
-        message: mockMessage,
-        say: mockSay,
-        setStatus: mockSetStatus,
-      });
-
-      expect(mockStreamer.stop).not.toHaveBeenCalled();
+    await messageHandler({
+      client: mockClient,
+      context: mockContext,
+      logger: mockLogger,
+      message: mockMessage,
+      say: mockSay,
+      setStatus: mockSetStatus,
     });
 
-    it('logs citation state and source count when metadata is present', async () => {
-      callLLM.mockResolvedValueOnce({
-        finalize_state: 'ready_to_finalize',
-        sources: [{ url: 'https://a.com' }],
-        source_index_map: { 'https://a.com': 1 },
-      });
+    expect(mockStreamer.stop).not.toHaveBeenCalled();
+  });
 
-      await messageHandler({
-        client: mockClient,
-        context: mockContext,
-        logger: mockLogger,
-        message: mockMessage,
-        say: mockSay,
-        setStatus: mockSetStatus,
-      });
-
-      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('[citations]'));
-      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('state=ready_to_finalize'));
+  it('logs citation state and source count when metadata is present', async () => {
+    callLLM.mockResolvedValueOnce({
+      finalize_state: 'ready_to_finalize',
+      sources: [{ url: 'https://a.com' }],
+      source_index_map: { 'https://a.com': 1 },
     });
 
-    it('calls finalizeMetadataEnvelope after streamer.stop', async () => {
-      const metadata = {
-        finalize_state: 'ready_to_finalize',
-        sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs' }],
-        source_index_map: { 'https://docs.ed-fi.org': 1 },
-      };
-      callLLM.mockResolvedValueOnce(metadata);
-
-      await messageHandler({
-        client: mockClient,
-        context: mockContext,
-        logger: mockLogger,
-        message: mockMessage,
-        say: mockSay,
-        setStatus: mockSetStatus,
-      });
-
-      expect(finalizeMetadataEnvelope).toHaveBeenCalledWith(metadata);
+    await messageHandler({
+      client: mockClient,
+      context: mockContext,
+      logger: mockLogger,
+      message: mockMessage,
+      say: mockSay,
+      setStatus: mockSetStatus,
     });
 
-    it('passes logger to shouldFinalize', async () => {
-      await messageHandler({
-        client: mockClient,
-        context: mockContext,
-        logger: mockLogger,
-        message: mockMessage,
-        say: mockSay,
-        setStatus: mockSetStatus,
-      });
+    expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('[citations]'));
+    expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('state=ready_to_finalize'));
+  });
 
-      expect(shouldFinalize).toHaveBeenCalledWith(expect.any(String), mockLogger);
+  it('calls finalizeMetadataEnvelope after streamer.stop', async () => {
+    const metadata = {
+      finalize_state: 'ready_to_finalize',
+      sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs' }],
+      source_index_map: { 'https://docs.ed-fi.org': 1 },
+    };
+    callLLM.mockResolvedValueOnce(metadata);
+
+    await messageHandler({
+      client: mockClient,
+      context: mockContext,
+      logger: mockLogger,
+      message: mockMessage,
+      say: mockSay,
+      setStatus: mockSetStatus,
     });
 
-    it('rolls back finalization when streamer.stop throws', async () => {
-      shouldFinalize.mockReturnValueOnce(true);
-      mockStreamer.stop.mockRejectedValueOnce(new Error('stop failed'));
+    expect(finalizeMetadataEnvelope).toHaveBeenCalledWith(metadata);
+  });
 
-      await messageHandler({
-        client: mockClient,
-        context: mockContext,
-        logger: mockLogger,
-        message: mockMessage,
-        say: mockSay,
-        setStatus: mockSetStatus,
-      });
-
-      expect(rollbackFinalization).toHaveBeenCalledWith('C123:1234567890.000000');
-      expect(mockLogger.error).toHaveBeenCalled();
+  it('passes logger to shouldFinalize', async () => {
+    await messageHandler({
+      client: mockClient,
+      context: mockContext,
+      logger: mockLogger,
+      message: mockMessage,
+      say: mockSay,
+      setStatus: mockSetStatus,
     });
 
-    it('does not roll back when shouldFinalize returns false (no slot was claimed)', async () => {
-      shouldFinalize.mockReturnValueOnce(false);
+    expect(shouldFinalize).toHaveBeenCalledWith(expect.any(String), mockLogger);
+  });
 
-      await messageHandler({
-        client: mockClient,
-        context: mockContext,
-        logger: mockLogger,
-        message: mockMessage,
-        say: mockSay,
-        setStatus: mockSetStatus,
-      });
+  it('rolls back finalization when streamer.stop throws', async () => {
+    shouldFinalize.mockReturnValueOnce(true);
+    mockStreamer.stop.mockRejectedValueOnce(new Error('stop failed'));
 
-      expect(rollbackFinalization).not.toHaveBeenCalled();
+    await messageHandler({
+      client: mockClient,
+      context: mockContext,
+      logger: mockLogger,
+      message: mockMessage,
+      say: mockSay,
+      setStatus: mockSetStatus,
     });
+
+    expect(rollbackFinalization).toHaveBeenCalledWith('C123:1234567890.000000');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('does not roll back when shouldFinalize returns false (no slot was claimed)', async () => {
+    shouldFinalize.mockReturnValueOnce(false);
+
+    await messageHandler({
+      client: mockClient,
+      context: mockContext,
+      logger: mockLogger,
+      message: mockMessage,
+      say: mockSay,
+      setStatus: mockSetStatus,
+    });
+
+    expect(rollbackFinalization).not.toHaveBeenCalled();
+  });
 });

--- a/apps/fiona-slack/tests/listeners/events/app-mention.test.js
+++ b/apps/fiona-slack/tests/listeners/events/app-mention.test.js
@@ -3,7 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 // Mock the LLM caller and rate limiter before importing the module under test
 jest.unstable_mockModule('../../../src/agent/interaction-store.js', () => ({
@@ -27,6 +27,8 @@ jest.unstable_mockModule('../../../src/agent/llm-caller.js', () => ({
     FINALIZED: 'finalized',
     DEGRADED_NO_METADATA: 'degraded_no_metadata',
   },
+  TOOL_CALL_DEPTH_EXCEEDED_CODE: 'MAX_TOOL_CALL_DEPTH_EXCEEDED',
+  TOOL_CALL_DEPTH_EXCEEDED_MESSAGE: 'The AI encountered too many tool invocations. Please try a simpler request.',
 }));
 
 jest.unstable_mockModule('../../../src/agent/rate-limiter.js', () => ({
@@ -35,9 +37,11 @@ jest.unstable_mockModule('../../../src/agent/rate-limiter.js', () => ({
 
 // Simulate the real fallback behaviour: when history is empty, return [currentText as user message].
 jest.unstable_mockModule('../../../src/agent/thread-history.js', () => ({
-  buildThreadHistory: jest.fn().mockImplementation((_client, _channel, _ts, { currentText = null } = {}) =>
-    Promise.resolve(currentText ? [{ role: 'user', content: currentText }] : []),
-  ),
+  buildThreadHistory: jest
+    .fn()
+    .mockImplementation((_client, _channel, _ts, { currentText = null } = {}) =>
+      Promise.resolve(currentText ? [{ role: 'user', content: currentText }] : []),
+    ),
 }));
 
 jest.unstable_mockModule('../../../src/agent/utils/idempotent-finalize.js', () => ({
@@ -45,7 +49,6 @@ jest.unstable_mockModule('../../../src/agent/utils/idempotent-finalize.js', () =
   shouldFinalize: jest.fn().mockReturnValue(true),
   rollbackFinalization: jest.fn(),
 }));
-
 
 const { appMentionCallback } = await import('../../../src/listeners/events/app_mention.js');
 const { callLLM, finalizeMetadataEnvelope } = await import('../../../src/agent/llm-caller.js');
@@ -104,11 +107,13 @@ describe('appMentionCallback', () => {
     expect(callLLM).not.toHaveBeenCalled();
 
     expect(recordInteraction).toHaveBeenCalledTimes(1);
-    expect(recordInteraction).toHaveBeenCalledWith(expect.objectContaining({
-      rateLimited: true,
-      status: 'error',
-      errorType: 'rate_limited',
-    }));
+    expect(recordInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rateLimited: true,
+        status: 'error',
+        errorType: 'rate_limited',
+      }),
+    );
     // recordInteraction is fired before say() but not awaited — say() is not blocked on the Cosmos write
     expect(recordInteraction.mock.invocationCallOrder[0]).toBeLessThan(mockSay.mock.invocationCallOrder[0]);
   });
@@ -133,17 +138,13 @@ describe('appMentionCallback', () => {
   it('uses event.thread_ts as thread_ts when present', async () => {
     mockEvent.thread_ts = '1234567890.000000';
     await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
-    expect(mockClient.chatStream).toHaveBeenCalledWith(
-      expect.objectContaining({ thread_ts: '1234567890.000000' }),
-    );
+    expect(mockClient.chatStream).toHaveBeenCalledWith(expect.objectContaining({ thread_ts: '1234567890.000000' }));
   });
 
   it('falls back to event.ts as thread_ts when thread_ts is absent', async () => {
     delete mockEvent.thread_ts;
     await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
-    expect(mockClient.chatStream).toHaveBeenCalledWith(
-      expect.objectContaining({ thread_ts: '1234567890.000001' }),
-    );
+    expect(mockClient.chatStream).toHaveBeenCalledWith(expect.objectContaining({ thread_ts: '1234567890.000001' }));
   });
 
   it('sends a warning and logs error when an exception occurs', async () => {
@@ -230,61 +231,61 @@ describe('appMentionCallback', () => {
     expect(callLLM).not.toHaveBeenCalled();
   });
 
-    it('skips streamer.stop when shouldFinalize returns false', async () => {
-      shouldFinalize.mockReturnValueOnce(false);
+  it('skips streamer.stop when shouldFinalize returns false', async () => {
+    shouldFinalize.mockReturnValueOnce(false);
 
-      await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
+    await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
 
-      expect(mockStreamer.stop).not.toHaveBeenCalled();
+    expect(mockStreamer.stop).not.toHaveBeenCalled();
+  });
+
+  it('logs citation state and source count when metadata is present', async () => {
+    callLLM.mockResolvedValueOnce({
+      finalize_state: 'ready_to_finalize',
+      sources: [{ url: 'https://a.com' }],
+      source_index_map: { 'https://a.com': 1 },
     });
 
-    it('logs citation state and source count when metadata is present', async () => {
-      callLLM.mockResolvedValueOnce({
-        finalize_state: 'ready_to_finalize',
-        sources: [{ url: 'https://a.com' }],
-        source_index_map: { 'https://a.com': 1 },
-      });
+    await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
 
-      await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
+    expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('[citations]'));
+    expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('state=ready_to_finalize'));
+  });
 
-      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('[citations]'));
-      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('state=ready_to_finalize'));
-    });
+  it('calls finalizeMetadataEnvelope after streamer.stop', async () => {
+    const metadata = {
+      finalize_state: 'ready_to_finalize',
+      sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs' }],
+      source_index_map: { 'https://docs.ed-fi.org': 1 },
+    };
+    callLLM.mockResolvedValueOnce(metadata);
 
-    it('calls finalizeMetadataEnvelope after streamer.stop', async () => {
-      const metadata = {
-        finalize_state: 'ready_to_finalize',
-        sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs' }],
-        source_index_map: { 'https://docs.ed-fi.org': 1 },
-      };
-      callLLM.mockResolvedValueOnce(metadata);
+    await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
 
-      await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
+    expect(finalizeMetadataEnvelope).toHaveBeenCalledWith(metadata);
+  });
 
-      expect(finalizeMetadataEnvelope).toHaveBeenCalledWith(metadata);
-    });
+  it('passes logger to shouldFinalize', async () => {
+    await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
 
-    it('passes logger to shouldFinalize', async () => {
-      await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
+    expect(shouldFinalize).toHaveBeenCalledWith(expect.any(String), mockLogger);
+  });
 
-      expect(shouldFinalize).toHaveBeenCalledWith(expect.any(String), mockLogger);
-    });
+  it('rolls back finalization when streamer.stop throws', async () => {
+    shouldFinalize.mockReturnValueOnce(true);
+    mockStreamer.stop.mockRejectedValueOnce(new Error('stop failed'));
 
-    it('rolls back finalization when streamer.stop throws', async () => {
-      shouldFinalize.mockReturnValueOnce(true);
-      mockStreamer.stop.mockRejectedValueOnce(new Error('stop failed'));
+    await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
 
-      await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
+    expect(rollbackFinalization).toHaveBeenCalledWith('C123:1234567890.000001');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
 
-      expect(rollbackFinalization).toHaveBeenCalledWith('C123:1234567890.000001');
-      expect(mockLogger.error).toHaveBeenCalled();
-    });
+  it('does not roll back when shouldFinalize returns false (no slot was claimed)', async () => {
+    shouldFinalize.mockReturnValueOnce(false);
 
-    it('does not roll back when shouldFinalize returns false (no slot was claimed)', async () => {
-      shouldFinalize.mockReturnValueOnce(false);
+    await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
 
-      await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
-
-      expect(rollbackFinalization).not.toHaveBeenCalled();
-    });
+    expect(rollbackFinalization).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #12

Adds a \`MAX_RECURSION_DEPTH\` constant (default 10) and a depth guard to \`callOpenAICompatible()\` to prevent stack overflow from runaway tool call loops.

## Changes
- \`llm-caller.js\`: exported \`MAX_RECURSION_DEPTH\`, added \`depth\` parameter, guard at entry, pass \`depth + 1\` at recursive call site
- New test: \`tests/agent/llm-caller.recursion.test.js\`

## Testing
19 suites, 237 tests passing.