### PR TITLE
fix(ai-50): validate AZURE_AGENT_ID at startup for foundry provider

### DIFF
--- a/apps/fiona-slack/src/agent/llm-caller.js
+++ b/apps/fiona-slack/src/agent/llm-caller.js
@@ -6,6 +6,7 @@
 import { AIProjectClient } from '@azure/ai-projects';
 import { DefaultAzureCredential } from '@azure/identity';
 import { AzureOpenAI, OpenAI } from 'openai';
+import { validateAzureAgentId } from './startup-validator.js';
 import { perplexitySearchDefinition } from './tools/perplexity-search.js';
 import {
   incrementDegradedNoMetadataCount,
@@ -562,7 +563,8 @@ async function callAzureAgent(streamer, prompts, logger) {
     throw new Error('Azure AI Foundry agent is not configured. Set AZURE_PROJECT_ENDPOINT and AZURE_AGENT_ID.');
   }
 
-  const agentParts = AZURE_AGENT_ID.split(':');
+  const validatedAgentId = validateAzureAgentId(AZURE_AGENT_ID);
+  const agentParts = validatedAgentId.split(':');
   const agentName = agentParts[0];
   const agentVersion = agentParts.length > 1 ? agentParts[1] : '1';
 

--- a/apps/fiona-slack/src/agent/startup-validator.js
+++ b/apps/fiona-slack/src/agent/startup-validator.js
@@ -7,8 +7,37 @@
  * Validates required environment variables at startup.
  * Throws an Error with a descriptive message if any required variable is missing.
  */
+export function validateAzureAgentId(id) {
+  const value = typeof id === 'string' ? id.trim() : '';
+  if (!value) {
+    throw new Error('AZURE_AGENT_ID environment variable is required when using the Foundry provider.');
+  }
+
+  const [name, version, ...extra] = value.split(':');
+  if (extra.length > 0) {
+    throw new Error('AZURE_AGENT_ID must be in the form "name" or "name:version" where version is numeric or semver.');
+  }
+
+  const namePattern = /^[A-Za-z0-9_-]+$/;
+  if (!name || !namePattern.test(name)) {
+    throw new Error('AZURE_AGENT_ID name must contain only letters, numbers, hyphens, or underscores.');
+  }
+
+  if (version !== undefined) {
+    const versionPattern = /^(?:\d+|\d+\.\d+|\d+\.\d+\.\d+)$/;
+    if (!versionPattern.test(version)) {
+      throw new Error('AZURE_AGENT_ID version must be numeric or semver-like (for example: 1, 1.0, 1.0.0).');
+    }
+  }
+
+  return value;
+}
+
 export function validateStartupConfig() {
-  if (process.env.LLM_PROVIDER === 'foundry' && !process.env.AZURE_AGENT_ID) {
-    throw new Error('AZURE_AGENT_ID environment variable is required when LLM_PROVIDER=foundry');
+  const providerFromEnv = process.env.LLM_PROVIDER;
+  const isFoundryProvider = providerFromEnv === 'foundry' || (!providerFromEnv && !!process.env.AZURE_PROJECT_ENDPOINT);
+
+  if (isFoundryProvider) {
+    validateAzureAgentId(process.env.AZURE_AGENT_ID);
   }
 }

--- a/apps/fiona-slack/src/agent/startup-validator.js
+++ b/apps/fiona-slack/src/agent/startup-validator.js
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+/**
+ * Validates required environment variables at startup.
+ * Throws an Error with a descriptive message if any required variable is missing.
+ */
+export function validateStartupConfig() {
+  if (process.env.LLM_PROVIDER === 'foundry' && !process.env.AZURE_AGENT_ID) {
+    throw new Error('AZURE_AGENT_ID environment variable is required when LLM_PROVIDER=foundry');
+  }
+}

--- a/apps/fiona-slack/src/app.js
+++ b/apps/fiona-slack/src/app.js
@@ -6,6 +6,7 @@
 import 'dotenv/config';
 import { App, LogLevel } from '@slack/bolt';
 import { registerListeners } from './listeners/index.js';
+import { validateStartupConfig } from './agent/startup-validator.js';
 
 const LOG_LEVEL_MAP = {
   debug: LogLevel.DEBUG,
@@ -84,6 +85,7 @@ registerListeners(app);
 // Start the Bolt app
 (async () => {
   try {
+    validateStartupConfig();
     await app.start();
     app.logger.info('⚡️ Bolt app is running!');
   } catch (error) {

--- a/apps/fiona-slack/src/app.js
+++ b/apps/fiona-slack/src/app.js
@@ -5,8 +5,8 @@
 
 import 'dotenv/config';
 import { App, LogLevel } from '@slack/bolt';
-import { registerListeners } from './listeners/index.js';
 import { validateStartupConfig } from './agent/startup-validator.js';
+import { registerListeners } from './listeners/index.js';
 
 const LOG_LEVEL_MAP = {
   debug: LogLevel.DEBUG,

--- a/apps/fiona-slack/tests/agent/startup-validator.test.js
+++ b/apps/fiona-slack/tests/agent/startup-validator.test.js
@@ -3,8 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import { describe, it, expect, afterEach } from '@jest/globals';
-import { validateStartupConfig } from '../../src/agent/startup-validator.js';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { validateAzureAgentId, validateStartupConfig } from '../../src/agent/startup-validator.js';
 
 describe('validateStartupConfig', () => {
   const originalEnv = { ...process.env };
@@ -25,22 +25,65 @@ describe('validateStartupConfig', () => {
   it('throws when LLM_PROVIDER is foundry and AZURE_AGENT_ID is missing', () => {
     process.env.LLM_PROVIDER = 'foundry';
     delete process.env.AZURE_AGENT_ID;
-    expect(() => validateStartupConfig()).toThrow(
-      'AZURE_AGENT_ID environment variable is required when LLM_PROVIDER=foundry',
-    );
+    expect(() => validateStartupConfig()).toThrow('AZURE_AGENT_ID environment variable is required');
   });
 
   it('throws when LLM_PROVIDER is foundry and AZURE_AGENT_ID is empty string', () => {
     process.env.LLM_PROVIDER = 'foundry';
     process.env.AZURE_AGENT_ID = '';
-    expect(() => validateStartupConfig()).toThrow(
-      'AZURE_AGENT_ID environment variable is required when LLM_PROVIDER=foundry',
-    );
+    expect(() => validateStartupConfig()).toThrow('AZURE_AGENT_ID environment variable is required');
   });
 
   it('does not throw when LLM_PROVIDER is foundry and AZURE_AGENT_ID is set', () => {
     process.env.LLM_PROVIDER = 'foundry';
     process.env.AZURE_AGENT_ID = 'my-agent';
     expect(() => validateStartupConfig()).not.toThrow();
+  });
+
+  it('requires AZURE_AGENT_ID when provider is inferred from AZURE_PROJECT_ENDPOINT', () => {
+    delete process.env.LLM_PROVIDER;
+    process.env.AZURE_PROJECT_ENDPOINT = 'https://example.services.ai.azure.com';
+    delete process.env.AZURE_AGENT_ID;
+    expect(() => validateStartupConfig()).toThrow('AZURE_AGENT_ID environment variable is required');
+  });
+
+  it('does not require AZURE_AGENT_ID when provider is not foundry and endpoint is unset', () => {
+    delete process.env.LLM_PROVIDER;
+    delete process.env.AZURE_PROJECT_ENDPOINT;
+    delete process.env.AZURE_AGENT_ID;
+    expect(() => validateStartupConfig()).not.toThrow();
+  });
+
+  describe('validateAzureAgentId', () => {
+    it('accepts valid values', () => {
+      const valid = ['agent', 'agent_name-1', 'agent:1', 'agent:1.0', 'agent:1.0.0'];
+      for (const id of valid) {
+        expect(validateAzureAgentId(id)).toBe(id);
+      }
+    });
+
+    it('rejects missing or whitespace-only values', () => {
+      expect(() => validateAzureAgentId(undefined)).toThrow('AZURE_AGENT_ID environment variable is required');
+      expect(() => validateAzureAgentId('')).toThrow('AZURE_AGENT_ID environment variable is required');
+      expect(() => validateAzureAgentId('   ')).toThrow('AZURE_AGENT_ID environment variable is required');
+    });
+
+    it('rejects invalid characters in agent name', () => {
+      expect(() => validateAzureAgentId('agent name')).toThrow('AZURE_AGENT_ID name must contain only');
+      expect(() => validateAzureAgentId('agent!')).toThrow('AZURE_AGENT_ID name must contain only');
+      expect(() => validateAzureAgentId(':1.0.0')).toThrow('AZURE_AGENT_ID name must contain only');
+    });
+
+    it('rejects malformed version segments', () => {
+      expect(() => validateAzureAgentId('agent:')).toThrow('AZURE_AGENT_ID version must be numeric or semver-like');
+      expect(() => validateAzureAgentId('agent:1.0.0.1')).toThrow(
+        'AZURE_AGENT_ID version must be numeric or semver-like',
+      );
+      expect(() => validateAzureAgentId('agent:v1')).toThrow('AZURE_AGENT_ID version must be numeric or semver-like');
+    });
+
+    it('rejects values with more than one colon', () => {
+      expect(() => validateAzureAgentId('agent:1:extra')).toThrow('AZURE_AGENT_ID must be in the form');
+    });
   });
 });

--- a/apps/fiona-slack/tests/agent/startup-validator.test.js
+++ b/apps/fiona-slack/tests/agent/startup-validator.test.js
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { validateStartupConfig } from '../../src/agent/startup-validator.js';
+
+describe('validateStartupConfig', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('does not throw when LLM_PROVIDER is not foundry', () => {
+    process.env.LLM_PROVIDER = 'openai';
+    delete process.env.AZURE_AGENT_ID;
+    expect(() => validateStartupConfig()).not.toThrow();
+  });
+
+  it('throws when LLM_PROVIDER is foundry and AZURE_AGENT_ID is missing', () => {
+    process.env.LLM_PROVIDER = 'foundry';
+    delete process.env.AZURE_AGENT_ID;
+    expect(() => validateStartupConfig()).toThrow(
+      'AZURE_AGENT_ID environment variable is required when LLM_PROVIDER=foundry',
+    );
+  });
+
+  it('throws when LLM_PROVIDER is foundry and AZURE_AGENT_ID is empty string', () => {
+    process.env.LLM_PROVIDER = 'foundry';
+    process.env.AZURE_AGENT_ID = '';
+    expect(() => validateStartupConfig()).toThrow(
+      'AZURE_AGENT_ID environment variable is required when LLM_PROVIDER=foundry',
+    );
+  });
+
+  it('does not throw when LLM_PROVIDER is foundry and AZURE_AGENT_ID is set', () => {
+    process.env.LLM_PROVIDER = 'foundry';
+    process.env.AZURE_AGENT_ID = 'my-agent';
+    expect(() => validateStartupConfig()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #16

Adds \`validateStartupConfig()\` called before \`app.start()\`. When \`LLM_PROVIDER=foundry\` and \`AZURE_AGENT_ID\` is missing or empty, the app exits with a clear error rather than failing on first request.

## Changes
- New: \`src/agent/startup-validator.js\`
- \`src/app.js\`: import and call \`validateStartupConfig()\` before \`app.start()\`
- New test: \`tests/agent/startup-validator.test.js\`

## Testing
19 suites, 240 tests passing.