### PR TITLE
fix: pass cosmosAccountName to Bicep deployment and correct minLength

### DIFF
--- a/.github/workflows/deploy-fiona-slack-container.yml
+++ b/.github/workflows/deploy-fiona-slack-container.yml
@@ -97,6 +97,7 @@ jobs:
             cosmosKey="${{ secrets.COSMOS_KEY }}" \
             cosmosDatabase="${{ vars.COSMOS_DATABASE || 'chatbot' }}" \
             cosmosContainer="${{ vars.COSMOS_CONTAINER || 'feedback' }}" \
+            cosmosAccountName="${{ vars.COSMOS_ACCOUNT_NAME }}" \
             deploymentType="${{ inputs.environment || 'insiders' }}" \
             skipRoleAssignments=true
 

--- a/infra/fiona-slack-container/main.bicep
+++ b/infra/fiona-slack-container/main.bicep
@@ -87,7 +87,7 @@ param cosmosDatabase string = 'chatbot'
 param cosmosContainer string = 'feedback'
 
 @description('Cosmos DB account name (required for provisioning the interactions and feedback containers)')
-@minLength(1)
+@minLength(3)
 param cosmosAccountName string
 
 @description('Cosmos DB container name for interaction/usage analytics storage')


### PR DESCRIPTION
## Summary

- **`main.bicep`**: Changed `@minLength(1)` to `@minLength(3)` to match Azure's actual Cosmos DB account name constraint (3–44 chars), eliminating the BCP334 Bicep warning that surfaced after PR #27.
- **`deploy-fiona-slack-container.yml`**: Added `cosmosAccountName` parameter wired to `vars.COSMOS_ACCOUNT_NAME`. Without this, the required Bicep parameter had no value at deploy time, causing the deployment to fail.

## Action Required

Add `COSMOS_ACCOUNT_NAME` as a GitHub Actions variable in **Settings → Secrets and variables → Actions → Variables** with the name of the existing Cosmos DB account (e.g. `fiona-cosmos`).

## Test plan

- [ ] Add `COSMOS_ACCOUNT_NAME` repo variable in GitHub Actions settings
- [ ] Trigger a deployment and confirm the BCP334 warning is gone
- [ ] Confirm the Cosmos DB containers are provisioned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)