### PR TITLE
[AI-94] fix: buffer Perplexity text and linkify [n] markers after citations arrive

### DIFF
--- a/apps/fiona-slack/src/agent/llm-caller.js
+++ b/apps/fiona-slack/src/agent/llm-caller.js
@@ -247,7 +247,7 @@ function transitionMetadataState(envelope, newState) {
   };
 
   const allowed = validTransitions[currentState];
-  if (!allowed || !allowed.includes(newState)) {
+  if (!allowed?.includes(newState)) {
     throw new Error(`Invalid metadata state transition: ${currentState} -> ${newState}`);
   }
 
@@ -484,7 +484,7 @@ function createCitationAwareAppender(streamer) {
  * @param {Array} prompts
  * @returns {Promise<string[]>} Citation URL strings (may be empty)
  */
-async function callPerplexityChat(streamer, prompts) {
+export async function callPerplexityChat(streamer, prompts) {
   if (!perplexityClient) {
     throw new Error('Perplexity client is not configured.');
   }
@@ -502,17 +502,16 @@ async function callPerplexityChat(streamer, prompts) {
     stream: true,
   });
 
-  // Collect citations from chunks; last one wins.
+  // Buffer all text chunks during streaming so that citation markers can be
+  // linkified after `source_index_map` has been fully populated.  Emitting
+  // per-chunk would always see an empty map because Perplexity delivers
+  // citations on the *last* chunk, after the text deltas.
   let citations = [];
-  const appender = createCitationAwareAppender(streamer);
+  let textBuffer = '';
 
   for await (const chunk of response) {
     if (Array.isArray(chunk.citations)) {
       citations = chunk.citations;
-
-      if (citations.length > 0 && streamer?.__citation_metadata) {
-        aggregatePerplexityMetadata(streamer.__citation_metadata, { citations });
-      }
     }
 
     const delta = chunk?.choices?.[0]?.delta;
@@ -535,15 +534,23 @@ async function callPerplexityChat(streamer, prompts) {
     }
 
     if (text) {
-      await appender.append(text);
+      textBuffer += text;
     }
   }
 
-  await appender.flush();
-
-  // Read the final chunk's citations one last time in case they were updated after the last text delta
-  if (streamer?.__citation_metadata && citations.length > 0) {
+  // Aggregate citations into the metadata envelope so source_index_map is
+  // fully populated before we linkify.
+  if (citations.length > 0 && streamer?.__citation_metadata) {
     aggregatePerplexityMetadata(streamer.__citation_metadata, { citations });
+  }
+
+  // Linkify [n] markers using the now-populated source_index_map, then emit
+  // a single append call.  Skipping the append entirely when there is no text
+  // avoids sending an empty markdown block to Slack.
+  if (textBuffer) {
+    const sourceIndexMap = streamer?.__citation_metadata?.source_index_map || {};
+    const linkifiedText = linkifyCitationMarkers(textBuffer, sourceIndexMap);
+    await streamer.append({ markdown_text: linkifiedText });
   }
 
   return citations;

--- a/apps/fiona-slack/tests/agent/llm-caller.aggregate-perplexity.test.js
+++ b/apps/fiona-slack/tests/agent/llm-caller.aggregate-perplexity.test.js
@@ -7,7 +7,6 @@ import { describe, it, expect, jest } from '@jest/globals';
 
 jest.unstable_mockModule('@azure/ai-projects', () => ({ AIProjectClient: jest.fn() }));
 jest.unstable_mockModule('@azure/identity', () => ({ DefaultAzureCredential: jest.fn() }));
-jest.unstable_mockModule('openai', () => ({ OpenAI: jest.fn(), AzureOpenAI: jest.fn() }));
 jest.unstable_mockModule('../../src/agent/utils/citation-telemetry.js', () => ({
   recordMetadataWaitDuration: jest.fn(),
   recordSourceCount: jest.fn(),
@@ -15,7 +14,21 @@ jest.unstable_mockModule('../../src/agent/utils/citation-telemetry.js', () => ({
   incrementTotalResponseCount: jest.fn(),
 }));
 
-const { aggregatePerplexityMetadata } = await import('../../src/agent/llm-caller.js');
+// Capture the create mock so tests can set their own resolved value.
+const mockCreate = jest.fn();
+
+jest.unstable_mockModule('openai', () => ({
+  AzureOpenAI: jest.fn(),
+  OpenAI: jest.fn().mockImplementation(() => ({
+    chat: { completions: { create: mockCreate } },
+  })),
+}));
+
+// Set the env var BEFORE the dynamic import so the module-level initializer
+// picks it up and assigns `perplexityClient`.
+process.env.PERPLEXITY_API_KEY = 'test-key';
+
+const { aggregatePerplexityMetadata, callPerplexityChat } = await import('../../src/agent/llm-caller.js');
 
 function makeMetadata() {
   return {
@@ -49,5 +62,102 @@ describe('aggregatePerplexityMetadata', () => {
     const metadata = makeMetadata();
     expect(() => aggregatePerplexityMetadata(metadata, null)).not.toThrow();
     expect(metadata.sources).toHaveLength(0);
+  });
+});
+
+describe('callPerplexityChat – buffer and linkify', () => {
+  /**
+   * Build a fake async-iterable Perplexity streaming response.
+   * Each element may have { text, citations }.
+   */
+  function makeStream(chunks) {
+    return {
+      [Symbol.asyncIterator]() {
+        let i = 0;
+        return {
+          async next() {
+            if (i >= chunks.length) return { done: true, value: undefined };
+            const chunk = chunks[i++];
+            return {
+              done: false,
+              value: {
+                citations: chunk.citations,
+                choices: chunk.text !== undefined ? [{ delta: { content: chunk.text } }] : [],
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  function makeStreamer(metadata) {
+    const appended = [];
+    return {
+      __citation_metadata: metadata,
+      append: jest.fn(async ({ markdown_text }) => {
+        appended.push(markdown_text);
+      }),
+      _appended: appended,
+    };
+  }
+
+  it('buffers all text chunks and emits a single linkified append after citations arrive', async () => {
+    const metadata = makeMetadata();
+    const streamer = makeStreamer(metadata);
+
+    // Simulate: text in two chunks, citations on the last chunk.
+    mockCreate.mockResolvedValue(
+      makeStream([
+        { text: 'See [1] and ' },
+        { text: '[2] for details.', citations: ['https://first.example.com', 'https://second.example.com'] },
+      ]),
+    );
+
+    await callPerplexityChat(streamer, [{ role: 'user', content: 'hello' }]);
+
+    // Should emit exactly one append call containing fully linkified text.
+    expect(streamer.append).toHaveBeenCalledTimes(1);
+    const emittedText = streamer._appended[0];
+    expect(emittedText).toBe(
+      'See [[1]](https://first.example.com) and [[2]](https://second.example.com) for details.',
+    );
+  });
+
+  it('emits the buffered text as-is when no citations are returned', async () => {
+    const metadata = makeMetadata();
+    const streamer = makeStreamer(metadata);
+
+    mockCreate.mockResolvedValue(makeStream([{ text: 'No citations here.' }, { text: ' Done.' }]));
+
+    await callPerplexityChat(streamer, [{ role: 'user', content: 'hello' }]);
+
+    expect(streamer.append).toHaveBeenCalledTimes(1);
+    expect(streamer._appended[0]).toBe('No citations here. Done.');
+  });
+
+  it('returns the collected citation URLs', async () => {
+    const metadata = makeMetadata();
+    const streamer = makeStreamer(metadata);
+
+    mockCreate.mockResolvedValue(
+      makeStream([{ text: 'Result [1].', citations: ['https://result.example.com'] }]),
+    );
+
+    const citations = await callPerplexityChat(streamer, [{ role: 'user', content: 'hello' }]);
+
+    expect(citations).toEqual(['https://result.example.com']);
+  });
+
+  it('does not call streamer.append when there is no text', async () => {
+    const metadata = makeMetadata();
+    const streamer = makeStreamer(metadata);
+
+    // Only a citations chunk, no text delta.
+    mockCreate.mockResolvedValue(makeStream([{ citations: ['https://only-citation.example.com'] }]));
+
+    await callPerplexityChat(streamer, [{ role: 'user', content: 'hello' }]);
+
+    expect(streamer.append).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Fixes `callPerplexityChat` to buffer all text chunks during streaming, then linkify the complete response after citations are collected, before emitting a single `streamer.append()`
- Root cause: Perplexity delivers `citations` only in the final stream chunk, so `source_index_map` was always empty when inline per-chunk linkification ran — `[n]` markers were never converted to Slack hyperlinks
- The Slack `chatStream` API is append-only (no replace), so buffering and emitting once is the correct approach
- Loading/thinking indicator remains visible throughout buffering — no UX regression
- `createCitationAwareAppender` retained in the file for use by other providers

## Test plan

- [x] 4 new tests added to `llm-caller.aggregate-perplexity.test.js`:
  - Linkified output when citations arrive on last chunk
  - Plain-text passthrough when no citations returned
  - Correct citation URL array returned
  - `streamer.append` not called on empty response
- [x] All 272 tests pass across 22 suites
- [x] Pre-commit hook passed (lint + full suite)

Closes AI-94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)