### PR TITLE
[AI-119] add /fiona help slash command

### DIFF
--- a/apps/fiona-slack/manifest.json
+++ b/apps/fiona-slack/manifest.json
@@ -17,7 +17,15 @@
         },
         "assistant_view": {
             "assistant_description": "Ask Fiona anything about Ed-Fi, and she'll do her best to help you out!"
-        }
+        },
+        "slash_commands": [
+            {
+                "command": "/fiona",
+                "description": "Interact with Fiona, your Ed-Fi AI assistant",
+                "usage_hint": "[help | ask <question> | search <query>]",
+                "should_escape": false
+            }
+        ]
     },
     "oauth_config": {
         "scopes": {
@@ -27,6 +35,7 @@
                 "channels:history",
                 "channels:join",
                 "chat:write",
+                "commands",
                 "im:history",
                 "groups:history"
             ]

--- a/apps/fiona-slack/src/listeners/commands/fiona.js
+++ b/apps/fiona-slack/src/listeners/commands/fiona.js
@@ -26,8 +26,8 @@ export const fionaCommandCallback = async ({ command, ack, logger }) => {
   switch (subCommand) {
     case 'help':
     case '':
-    // Future slices add: case 'ask': ...; case 'search': ...;
     default:
+      // Future slices add: case 'ask': ...; case 'search': ...;
       await handleHelp({ command, ack, logger });
       break;
   }

--- a/apps/fiona-slack/src/listeners/commands/fiona.js
+++ b/apps/fiona-slack/src/listeners/commands/fiona.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { recordInteraction } from '../../agent/interaction-store.js';
+
+const HELP_TEXT = `*Fiona — your Ed-Fi AI assistant* :wave:
+Fiona helps you navigate Ed-Fi documentation, standards, and community resources using natural language.
+
+*Available commands:*
+\`\`\`
+/fiona help              Show this help message
+/fiona ask <question>    Ask Fiona a question about Ed-Fi (coming soon)
+/fiona search <query>    Search Ed-Fi documentation (coming soon)
+\`\`\`
+_Tip: You can also @-mention Fiona in any channel, or send her a direct message._`;
+
+/**
+ * Handles the /fiona slash command. Routes to a sub-command handler or falls
+ * back to help for unrecognized / missing input. Never invokes the LLM.
+ */
+export const fionaCommandCallback = async ({ command, ack, logger }) => {
+  const subCommand = (command.text ?? '').trim().split(/\s+/)[0].toLowerCase();
+
+  switch (subCommand) {
+    case 'help':
+    case '':
+    // Future slices add: case 'ask': ...; case 'search': ...;
+    default:
+      await handleHelp({ command, ack, logger });
+      break;
+  }
+};
+
+async function handleHelp({ command, ack, logger }) {
+  const { user_id, team_id, channel_id, trigger_id } = command;
+
+  // ack(string) sends an immediate ephemeral response to the invoking user.
+  await ack(HELP_TEXT);
+
+  // Fire-and-forget — do not block ack on the Cosmos write.
+  // Slash commands have no thread_ts or message_ts; trigger_id is unique per
+  // invocation and serves as both identifiers for the Cosmos document ID.
+  recordInteraction({
+    userId: user_id,
+    teamId: team_id,
+    channelId: channel_id,
+    threadTs: trigger_id,
+    messageTs: trigger_id,
+    interactionType: 'slash_help',
+    status: 'success',
+    errorType: null,
+    rateLimited: false,
+    logger,
+  }).catch((err) => logger?.warn?.(`Failed to record slash_help interaction: ${err.message}`));
+}

--- a/apps/fiona-slack/src/listeners/commands/index.js
+++ b/apps/fiona-slack/src/listeners/commands/index.js
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { fionaCommandCallback } from './fiona.js';
+
+/**
+ * @param {import("@slack/bolt").App} app
+ */
+export const register = (app) => {
+  app.command('/fiona', fionaCommandCallback);
+};

--- a/apps/fiona-slack/src/listeners/index.js
+++ b/apps/fiona-slack/src/listeners/index.js
@@ -5,6 +5,7 @@
 
 import * as actions from './actions/index.js';
 import * as assistant from './assistant/index.js';
+import * as commands from './commands/index.js';
 import * as events from './events/index.js';
 
 /**
@@ -14,4 +15,5 @@ export const registerListeners = (app) => {
   actions.register(app);
   events.register(app);
   assistant.register(app);
+  commands.register(app);
 };

--- a/apps/fiona-slack/tests/listeners/commands/fiona.test.js
+++ b/apps/fiona-slack/tests/listeners/commands/fiona.test.js
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// Mock interaction-store before importing the module under test.
+// llm-caller is intentionally NOT mocked — if fiona.js ever imports it,
+// Jest will error loudly, enforcing the "no LLM call" requirement.
+const mockRecordInteraction = jest.fn().mockResolvedValue(undefined);
+
+jest.unstable_mockModule('../../../src/agent/interaction-store.js', () => ({
+  recordInteraction: mockRecordInteraction,
+}));
+
+const { fionaCommandCallback } = await import('../../../src/listeners/commands/fiona.js');
+
+describe('fionaCommandCallback', () => {
+  let mockAck;
+  let mockLogger;
+  let mockCommand;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAck = jest.fn().mockResolvedValue(undefined);
+    mockLogger = { warn: jest.fn(), info: jest.fn(), error: jest.fn() };
+    mockCommand = {
+      user_id: 'U12345',
+      team_id: 'T99999',
+      channel_id: 'C67890',
+      trigger_id: 'trigger-abc-123',
+      text: 'help',
+    };
+  });
+
+  describe('help sub-command', () => {
+    it('calls ack() exactly once', async () => {
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      expect(mockAck).toHaveBeenCalledTimes(1);
+    });
+
+    it('ack() receives a string mentioning Fiona', async () => {
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      expect(mockAck).toHaveBeenCalledWith(expect.stringContaining('Fiona'));
+    });
+
+    it('ack() response includes /fiona help', async () => {
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      expect(mockAck).toHaveBeenCalledWith(expect.stringContaining('/fiona help'));
+    });
+
+    it('ack() response includes /fiona ask', async () => {
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      expect(mockAck).toHaveBeenCalledWith(expect.stringContaining('/fiona ask'));
+    });
+
+    it('ack() response includes /fiona search', async () => {
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      expect(mockAck).toHaveBeenCalledWith(expect.stringContaining('/fiona search'));
+    });
+
+    it('calls recordInteraction with interactionType slash_help', async () => {
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      await Promise.resolve(); // flush fire-and-forget
+      expect(mockRecordInteraction).toHaveBeenCalledWith(
+        expect.objectContaining({ interactionType: 'slash_help' }),
+      );
+    });
+
+    it('calls recordInteraction with status success', async () => {
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      await Promise.resolve();
+      expect(mockRecordInteraction).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'success' }),
+      );
+    });
+
+    it('calls recordInteraction with rateLimited false', async () => {
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      await Promise.resolve();
+      expect(mockRecordInteraction).toHaveBeenCalledWith(
+        expect.objectContaining({ rateLimited: false }),
+      );
+    });
+
+    it('calls recordInteraction with threadTs and messageTs equal to trigger_id', async () => {
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      await Promise.resolve();
+      expect(mockRecordInteraction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadTs: mockCommand.trigger_id,
+          messageTs: mockCommand.trigger_id,
+        }),
+      );
+    });
+
+    it('calls recordInteraction with correct userId, teamId, channelId', async () => {
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      await Promise.resolve();
+      expect(mockRecordInteraction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'U12345',
+          teamId: 'T99999',
+          channelId: 'C67890',
+        }),
+      );
+    });
+
+    it('ack() is called before recordInteraction (fire-and-forget ordering)', async () => {
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      await Promise.resolve();
+      expect(mockAck.mock.invocationCallOrder[0]).toBeLessThan(
+        mockRecordInteraction.mock.invocationCallOrder[0],
+      );
+    });
+  });
+
+  describe('empty sub-command (bare /fiona)', () => {
+    it('falls back to help when command.text is empty string', async () => {
+      mockCommand.text = '';
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      expect(mockAck).toHaveBeenCalledWith(expect.stringContaining('Fiona'));
+    });
+
+    it('falls back to help when command.text is whitespace only', async () => {
+      mockCommand.text = '   ';
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      expect(mockAck).toHaveBeenCalledWith(expect.stringContaining('Fiona'));
+    });
+
+    it('records slash_help on empty input', async () => {
+      mockCommand.text = '';
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      await Promise.resolve();
+      expect(mockRecordInteraction).toHaveBeenCalledWith(
+        expect.objectContaining({ interactionType: 'slash_help' }),
+      );
+    });
+  });
+
+  describe('unknown sub-command fallback', () => {
+    it.each([['foo'], ['bar'], ['ask'], ['search']])(
+      'falls back to help for unrecognized sub-command "%s"',
+      async (subCommand) => {
+        mockCommand.text = subCommand;
+        await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+        expect(mockAck).toHaveBeenCalledWith(expect.stringContaining('Fiona'));
+      },
+    );
+
+    it('records slash_help for unknown sub-command', async () => {
+      mockCommand.text = 'foo';
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      await Promise.resolve();
+      expect(mockRecordInteraction).toHaveBeenCalledWith(
+        expect.objectContaining({ interactionType: 'slash_help' }),
+      );
+    });
+  });
+
+  describe('resilience', () => {
+    it('does not throw when recordInteraction rejects', async () => {
+      mockRecordInteraction.mockRejectedValueOnce(new Error('cosmos down'));
+      await expect(
+        fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('logs a warning when recordInteraction rejects', async () => {
+      mockRecordInteraction.mockRejectedValueOnce(new Error('cosmos down'));
+      await fionaCommandCallback({ command: mockCommand, ack: mockAck, logger: mockLogger });
+      await Promise.resolve();
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('cosmos down'));
+    });
+  });
+});

--- a/apps/fiona-slack/tests/listeners/commands/fiona.test.js
+++ b/apps/fiona-slack/tests/listeners/commands/fiona.test.js
@@ -6,14 +6,16 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 
 // Mock interaction-store before importing the module under test.
-// llm-caller is intentionally NOT mocked — if fiona.js ever imports it,
-// Jest will error loudly, enforcing the "no LLM call" requirement.
 const mockRecordInteraction = jest.fn().mockResolvedValue(undefined);
 
 jest.unstable_mockModule('../../../src/agent/interaction-store.js', () => ({
   recordInteraction: mockRecordInteraction,
 }));
 
+// Enforce the "no LLM call" requirement by failing if the handler imports llm-caller.
+jest.unstable_mockModule('../../../src/agent/llm-caller.js', () => {
+  throw new Error('llm-caller must not be imported by /fiona slash command handlers');
+});
 const { fionaCommandCallback } = await import('../../../src/listeners/commands/fiona.js');
 
 describe('fionaCommandCallback', () => {

--- a/apps/fiona-slack/tests/listeners/index.test.js
+++ b/apps/fiona-slack/tests/listeners/index.test.js
@@ -9,6 +9,7 @@ import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 const mockActionsRegister = jest.fn();
 const mockEventsRegister = jest.fn();
 const mockAssistantRegister = jest.fn();
+const mockCommandsRegister = jest.fn();
 
 jest.unstable_mockModule('../../src/listeners/actions/index.js', () => ({
   register: mockActionsRegister,
@@ -22,6 +23,10 @@ jest.unstable_mockModule('../../src/listeners/assistant/index.js', () => ({
   register: mockAssistantRegister,
 }));
 
+jest.unstable_mockModule('../../src/listeners/commands/index.js', () => ({
+  register: mockCommandsRegister,
+}));
+
 const { registerListeners } = await import('../../src/listeners/index.js');
 
 describe('registerListeners', () => {
@@ -29,7 +34,7 @@ describe('registerListeners', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockApp = { action: jest.fn(), event: jest.fn(), assistant: jest.fn() };
+    mockApp = { action: jest.fn(), event: jest.fn(), assistant: jest.fn(), command: jest.fn() };
   });
 
   it('calls actions register with the app', () => {
@@ -47,10 +52,16 @@ describe('registerListeners', () => {
     expect(mockAssistantRegister).toHaveBeenCalledWith(mockApp);
   });
 
-  it('calls all three sub-registrations exactly once', () => {
+  it('calls commands register with the app', () => {
+    registerListeners(mockApp);
+    expect(mockCommandsRegister).toHaveBeenCalledWith(mockApp);
+  });
+
+  it('calls all four sub-registrations exactly once', () => {
     registerListeners(mockApp);
     expect(mockActionsRegister).toHaveBeenCalledTimes(1);
     expect(mockEventsRegister).toHaveBeenCalledTimes(1);
     expect(mockAssistantRegister).toHaveBeenCalledTimes(1);
+    expect(mockCommandsRegister).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Registers the /fiona Slack slash command with a help sub-command that returns an ephemeral guide to available commands. Unrecognized and empty sub-commands fall back to help. No LLM call is made. Interaction is recorded to Cosmos DB with interactionType: slash_help.