### PR TITLE
[AI-129] Capture all conversations in Cosmos DB for evaluation

### DIFF
--- a/.github/workflows/deploy-fiona-slack-container.yml
+++ b/.github/workflows/deploy-fiona-slack-container.yml
@@ -91,6 +91,7 @@ jobs:
             cosmosDatabase="${{ vars.COSMOS_DATABASE || 'chatbot' }}" \
             cosmosContainer="${{ vars.COSMOS_CONTAINER || 'feedback' }}" \
             cosmosAccountName="${{ vars.COSMOS_ACCOUNT_NAME }}" \
+            captureAllConversations=${{ vars.CAPTURE_ALL_CONVERSATIONS || 'false' }} \
             deploymentType="${{ inputs.environment || 'insiders' }}" \
             skipRoleAssignments=true
 

--- a/apps/fiona-slack/.env.sample
+++ b/apps/fiona-slack/.env.sample
@@ -18,7 +18,7 @@
 # Deployment type label recorded with feedback in Cosmos DB (local, insiders, production).
 DEPLOYMENT_TYPE=local
 
-# Optional, Cosmos DB for feedback storage. Supports three auth methods (in priority order):
+# Optional, Cosmos DB for feedback and conversation storage. Supports three auth methods (in priority order):
 #   1. Connection string:  set COSMOS_CONNECTION_STRING
 #   2. Endpoint + key:     set COSMOS_ENDPOINT and COSMOS_KEY
 #   3. Managed identity:   set COSMOS_ENDPOINT only (uses DefaultAzureCredential)
@@ -29,6 +29,12 @@ DEPLOYMENT_TYPE=local
 # COSMOS_DATABASE=chatbot
 # COSMOS_CONTAINER=feedback
 # COSMOS_USERS_CONTAINER=slack-users
+# COSMOS_INTERACTIONS_CONTAINER=interactions
+# COSMOS_CONVERSATIONS_CONTAINER=conversations
+
+# Optional, set to true to capture all conversations to Cosmos DB for analysis.
+# Requires Cosmos DB to be configured above.
+# CAPTURE_ALL_CONVERSATIONS=false
 
 # Optional, rate limiting per user (sliding window).
 # Set RATE_LIMIT_MAX_REQUESTS=0 to disable rate limiting entirely.

--- a/apps/fiona-slack/README.md
+++ b/apps/fiona-slack/README.md
@@ -111,7 +111,8 @@ The `.slack/` directory holds configuration for the [Slack CLI](https://tools.sl
    ```
 
    > [!TIP]
-   > To connect to a local CosmosDB with self-signed certificate, execute `npm run slack:unsafe`.
+   > To connect to a local CosmosDB with self-signed certificate in PowerShell, run
+   > `$env:NODE_TLS_REJECT_UNAUTHORIZED=0; slack run`.
 
 ### `apps.json` for production/CI
 

--- a/apps/fiona-slack/package.json
+++ b/apps/fiona-slack/package.json
@@ -6,12 +6,11 @@
   "main": "src/app.js",
   "scripts": {
     "start": "node src/app.js",
-    "slack:unsafe": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 slack run",
     "lint": "npx @biomejs/biome check src/",
     "lint:fix": "npx @biomejs/biome check --write src/",
     "test": "node --experimental-vm-modules node_modules/jest-cli/bin/jest.js",
     "test:ci": "node --experimental-vm-modules node_modules/jest-cli/bin/jest.js --coverage --reporters=default --reporters=jest-junit",
-    "setup:emulator": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 node scripts/setup-cosmos-emulator.js",
+    "setup:emulator": "node scripts/setup-cosmos-emulator.js",
     "load:slack-users": "node scripts/load-slack-users.js"
   },
   "author": "Ed-Fi Alliance, LLC",

--- a/apps/fiona-slack/scripts/setup-cosmos-emulator.js
+++ b/apps/fiona-slack/scripts/setup-cosmos-emulator.js
@@ -15,7 +15,6 @@
  */
 
 import { readFileSync } from 'node:fs';
-import https from 'node:https';
 import { CosmosClient } from '@azure/cosmos';
 
 // Load .env if present so COSMOS_CONNECTION_STRING etc. are available
@@ -31,18 +30,16 @@ try {
 
 const DATABASE_NAME = process.env.COSMOS_DATABASE || 'chatbot';
 const FEEDBACK_CONTAINER = process.env.COSMOS_CONTAINER || 'feedback';
-const INTERACTIONS_CONTAINER = 'interactions';
+const INTERACTIONS_CONTAINER = process.env.COSMOS_INTERACTIONS_CONTAINER || 'interactions';
 const CONVERSATIONS_CONTAINER = process.env.COSMOS_CONVERSATIONS_CONTAINER || 'conversations';
 
 // Build CosmosClient from connection string if available, otherwise fall back
 // to the well-known emulator endpoint + key.
-const tlsAgent = new https.Agent({ rejectUnauthorized: false });
 let client;
 
 if (process.env.COSMOS_CONNECTION_STRING) {
   client = new CosmosClient({
     connectionString: process.env.COSMOS_CONNECTION_STRING,
-    agent: tlsAgent,
   });
   console.log('Using COSMOS_CONNECTION_STRING from environment.');
 } else {
@@ -52,8 +49,9 @@ if (process.env.COSMOS_CONNECTION_STRING) {
   // system tray icon → "Copy Connection String", then set COSMOS_CONNECTION_STRING
   // in your .env.
   const key =
-    process.env.COSMOS_KEY || 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b5n5MBLzPU1z+OhS8OyX8+tU9J1A==';
-  client = new CosmosClient({ endpoint, key, agent: tlsAgent });
+    process.env.COSMOS_KEY ||
+    'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b5n5MBLzPU1z+OhS8OyX8+tU9J1A==';
+  client = new CosmosClient({ endpoint, key });
   console.log(`Using endpoint ${endpoint} (set COSMOS_CONNECTION_STRING in .env to override).`);
 }
 

--- a/apps/fiona-slack/scripts/setup-cosmos-emulator.js
+++ b/apps/fiona-slack/scripts/setup-cosmos-emulator.js
@@ -32,6 +32,7 @@ try {
 const DATABASE_NAME = process.env.COSMOS_DATABASE || 'chatbot';
 const FEEDBACK_CONTAINER = process.env.COSMOS_CONTAINER || 'feedback';
 const INTERACTIONS_CONTAINER = 'interactions';
+const CONVERSATIONS_CONTAINER = process.env.COSMOS_CONVERSATIONS_CONTAINER || 'conversations';
 
 // Build CosmosClient from connection string if available, otherwise fall back
 // to the well-known emulator endpoint + key.
@@ -145,6 +146,23 @@ async function main() {
     },
   });
   console.log(`Container '${USERS_CONTAINER}' ready.`);
+
+  // --- conversations container ---
+  await database.containers.createIfNotExists({
+    id: CONVERSATIONS_CONTAINER,
+    partitionKey: {
+      paths: ['/deploymentType', '/userId'],
+      kind: 'MultiHash',
+      version: 2,
+    },
+    defaultTtl: 31104000, // 360 days in seconds
+    indexingPolicy: {
+      indexingMode: 'consistent',
+      includedPaths: [{ path: '/*' }],
+      excludedPaths: [{ path: '/"_etag"/?' }],
+    },
+  });
+  console.log(`Container '${CONVERSATIONS_CONTAINER}' ready.`);
 
   if (!process.env.COSMOS_CONNECTION_STRING) {
     console.log('\nDone. Add this to your .env to connect the app:');

--- a/apps/fiona-slack/scripts/setup-cosmos-emulator.js
+++ b/apps/fiona-slack/scripts/setup-cosmos-emulator.js
@@ -153,7 +153,7 @@ async function main() {
       kind: 'MultiHash',
       version: 2,
     },
-    defaultTtl: 31104000, // 360 days in seconds
+    defaultTtl: 15552000, // 180 days in seconds
     indexingPolicy: {
       indexingMode: 'consistent',
       includedPaths: [{ path: '/*' }],

--- a/apps/fiona-slack/src/agent/conversation-capture-store.js
+++ b/apps/fiona-slack/src/agent/conversation-capture-store.js
@@ -3,8 +3,6 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import https from 'node:https';
-
 import { CosmosClient } from '@azure/cosmos';
 import { DefaultAzureCredential } from '@azure/identity';
 
@@ -23,6 +21,68 @@ const CONVERSATION_TTL_SECONDS = 31_104_000;
 let container = null;
 
 let warnedMissingConfig = false;
+const RETRYABLE_CODES = new Set([410, 429, 449, 500, 503]);
+const RECONNECT_CODES = new Set([410, 503]);
+
+/**
+ * @param {unknown} error
+ * @returns {string}
+ */
+function formatCosmosError(error) {
+  const fallback = error instanceof Error ? error.message : String(error);
+  const message = String(fallback || 'Unknown error')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const statusCode = Number(error?.statusCode);
+  const code = Number(error?.code);
+  const activityId = error?.activityId ?? error?.headers?.['x-ms-activity-id'];
+
+  const details = [
+    Number.isFinite(statusCode) ? `statusCode=${statusCode}` : null,
+    Number.isFinite(code) ? `code=${code}` : null,
+    activityId ? `activityId=${activityId}` : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  return details ? `${message} (${details})` : message;
+}
+
+/**
+ * @param {unknown} error
+ * @returns {number | null}
+ */
+function toNumericCode(error) {
+  const rawCode = error?.code ?? error?.statusCode;
+  const code = Number(rawCode);
+  if (Number.isFinite(code)) return code;
+
+  const message = String(error?.message ?? '').toLowerCase();
+  if (message.includes('410 response')) return 410;
+  if (message.includes('service is currently unavailable')) return 503;
+  return null;
+}
+
+function isEmulatorTarget() {
+  const target = `${COSMOS_CONNECTION_STRING ?? ''} ${COSMOS_ENDPOINT ?? ''}`.toLowerCase();
+  return target.includes('localhost') || target.includes('127.0.0.1');
+}
+
+function getRetryPolicy() {
+  if (process.env.NODE_ENV === 'test') {
+    return { maxAttempts: 2, baseDelayMs: 1, maxDelayMs: 5 };
+  }
+  if (isEmulatorTarget()) {
+    return { maxAttempts: 2, baseDelayMs: 200, maxDelayMs: 1000 };
+  }
+  return { maxAttempts: 3, baseDelayMs: 150, maxDelayMs: 800 };
+}
+
+function getDelayMs(policy, attempt) {
+  const baseDelay = Math.min(policy.baseDelayMs * 2 ** (attempt - 1), policy.maxDelayMs);
+  const jitter = Math.floor(Math.random() * Math.max(1, Math.floor(baseDelay * 0.2)));
+  return baseDelay + jitter;
+}
 
 /**
  * @param {{ warn?: (msg: string) => void } | null} [logger]
@@ -31,17 +91,15 @@ let warnedMissingConfig = false;
 async function getContainer(logger) {
   if (container) return container;
 
-  const tlsAgent = new https.Agent({ rejectUnauthorized: false });
   let client;
   if (COSMOS_CONNECTION_STRING) {
-    client = new CosmosClient(COSMOS_CONNECTION_STRING, { agent: tlsAgent });
+    client = new CosmosClient(COSMOS_CONNECTION_STRING);
   } else if (COSMOS_ENDPOINT && COSMOS_KEY) {
-    client = new CosmosClient({ endpoint: COSMOS_ENDPOINT, key: COSMOS_KEY, agent: tlsAgent });
+    client = new CosmosClient({ endpoint: COSMOS_ENDPOINT, key: COSMOS_KEY });
   } else if (COSMOS_ENDPOINT) {
     client = new CosmosClient({
       endpoint: COSMOS_ENDPOINT,
       aadCredentials: new DefaultAzureCredential(),
-      agent: tlsAgent,
     });
   } else {
     if (!warnedMissingConfig) {
@@ -114,7 +172,7 @@ export async function captureConversation({
       entryPoint,
       userMessage,
       botResponse,
-      threadHistory,
+      threadHistory: Array.isArray(threadHistory) ? threadHistory : [],
       llmProvider,
       llmModel,
       sources: sources ?? [],
@@ -123,11 +181,29 @@ export async function captureConversation({
       ttl: CONVERSATION_TTL_SECONDS,
     };
 
-    await c.items.upsert(doc, {
-      partitionKey: [doc.deploymentType, doc.userId],
-    });
+    const policy = getRetryPolicy();
+    for (let attempt = 1; attempt <= policy.maxAttempts; attempt++) {
+      try {
+        const activeContainer = attempt === 1 ? c : await getContainer(logger);
+        if (!activeContainer) return;
+        await activeContainer.items.upsert(doc, {
+          partitionKey: [doc.deploymentType, doc.userId],
+        });
+        return;
+      } catch (error) {
+        const code = toNumericCode(error);
+        const retryable = RETRYABLE_CODES.has(code);
+        if (!retryable || attempt === policy.maxAttempts) {
+          logger?.warn?.(`Failed to capture conversation to Cosmos DB: ${formatCosmosError(error)}`);
+          return;
+        }
+        if (RECONNECT_CODES.has(code)) {
+          container = null;
+        }
+        await new Promise((resolve) => setTimeout(resolve, getDelayMs(policy, attempt)));
+      }
+    }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    logger?.warn?.(`Failed to capture conversation to Cosmos DB: ${errorMessage}`);
+    logger?.warn?.(`Failed to capture conversation to Cosmos DB: ${formatCosmosError(error)}`);
   }
 }

--- a/apps/fiona-slack/src/agent/conversation-capture-store.js
+++ b/apps/fiona-slack/src/agent/conversation-capture-store.js
@@ -3,6 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import https from 'node:https';
+
 import { CosmosClient } from '@azure/cosmos';
 import { DefaultAzureCredential } from '@azure/identity';
 
@@ -29,15 +31,17 @@ let warnedMissingConfig = false;
 async function getContainer(logger) {
   if (container) return container;
 
+  const tlsAgent = new https.Agent({ rejectUnauthorized: false });
   let client;
   if (COSMOS_CONNECTION_STRING) {
-    client = new CosmosClient(COSMOS_CONNECTION_STRING);
+    client = new CosmosClient(COSMOS_CONNECTION_STRING, { agent: tlsAgent });
   } else if (COSMOS_ENDPOINT && COSMOS_KEY) {
-    client = new CosmosClient({ endpoint: COSMOS_ENDPOINT, key: COSMOS_KEY });
+    client = new CosmosClient({ endpoint: COSMOS_ENDPOINT, key: COSMOS_KEY, agent: tlsAgent });
   } else if (COSMOS_ENDPOINT) {
     client = new CosmosClient({
       endpoint: COSMOS_ENDPOINT,
       aadCredentials: new DefaultAzureCredential(),
+      agent: tlsAgent,
     });
   } else {
     if (!warnedMissingConfig) {

--- a/apps/fiona-slack/src/agent/conversation-capture-store.js
+++ b/apps/fiona-slack/src/agent/conversation-capture-store.js
@@ -14,13 +14,14 @@ const COSMOS_DATABASE = process.env.COSMOS_DATABASE || 'chatbot';
 const COSMOS_CONVERSATIONS_CONTAINER = process.env.COSMOS_CONVERSATIONS_CONTAINER || 'conversations';
 const DEPLOYMENT_TYPE = process.env.DEPLOYMENT_TYPE || 'local';
 
-// 360 days in seconds for per-document TTL
-const CONVERSATION_TTL_SECONDS = 31_104_000;
+// 180 days in seconds for per-document TTL
+const CONVERSATION_TTL_SECONDS = 15_552_000;
 
 /** @type {import('@azure/cosmos').Container | null} */
 let container = null;
 
 let warnedMissingConfig = false;
+let warnedInsecureProductionCosmosKey = false;
 const RETRYABLE_CODES = new Set([410, 429, 449, 500, 503]);
 const RECONNECT_CODES = new Set([410, 503]);
 
@@ -95,6 +96,15 @@ async function getContainer(logger) {
   if (COSMOS_CONNECTION_STRING) {
     client = new CosmosClient(COSMOS_CONNECTION_STRING);
   } else if (COSMOS_ENDPOINT && COSMOS_KEY) {
+    if (DEPLOYMENT_TYPE === 'production') {
+      if (!warnedInsecureProductionCosmosKey) {
+        warnedInsecureProductionCosmosKey = true;
+        logger?.warn?.(
+          'Conversation capture does not support COSMOS_KEY auth in production. Use COSMOS_CONNECTION_STRING or managed identity (COSMOS_ENDPOINT only).',
+        );
+      }
+      return null;
+    }
     client = new CosmosClient({ endpoint: COSMOS_ENDPOINT, key: COSMOS_KEY });
   } else if (COSMOS_ENDPOINT) {
     client = new CosmosClient({
@@ -131,6 +141,7 @@ async function getContainer(logger) {
  * @param {Array<{role: string, content: string}>} capture.threadHistory - Full thread context sent to LLM
  * @param {string} capture.llmProvider - LLM provider name (e.g. 'perplexity')
  * @param {string} capture.llmModel - LLM model name (e.g. 'sonar')
+ * @param {string} [capture.systemPromptVersion] - System prompt version identifier
  * @param {Array} [capture.sources] - Citation sources from metadata
  * @param {{ warn?: (msg: string) => void }} [capture.logger] - Optional logger
  */
@@ -146,6 +157,7 @@ export async function captureConversation({
   threadHistory,
   llmProvider,
   llmModel,
+  systemPromptVersion,
   sources,
   logger,
 }) {
@@ -156,9 +168,16 @@ export async function captureConversation({
     if (!c) return;
 
     if (!userId || !channelId || !threadTs || !messageTs || !entryPoint) {
-      logger?.warn?.(
-        `Missing required fields for capturing conversation: ${JSON.stringify({ userId, channelId, threadTs, messageTs, entryPoint })}`,
-      );
+      const missingFields = [
+        ['userId', userId],
+        ['channelId', channelId],
+        ['threadTs', threadTs],
+        ['messageTs', messageTs],
+        ['entryPoint', entryPoint],
+      ]
+        .filter(([, value]) => !value)
+        .map(([name]) => name);
+      logger?.warn?.(`Missing required fields for capturing conversation: ${missingFields.join(', ')}`);
       return;
     }
 
@@ -175,6 +194,7 @@ export async function captureConversation({
       threadHistory: Array.isArray(threadHistory) ? threadHistory : [],
       llmProvider,
       llmModel,
+      systemPromptVersion: systemPromptVersion ?? 'unknown',
       sources: sources ?? [],
       deploymentType: DEPLOYMENT_TYPE,
       timestamp: new Date().toISOString(),

--- a/apps/fiona-slack/src/agent/conversation-capture-store.js
+++ b/apps/fiona-slack/src/agent/conversation-capture-store.js
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { CosmosClient } from '@azure/cosmos';
+import { DefaultAzureCredential } from '@azure/identity';
+
+const CAPTURE_ALL_CONVERSATIONS = process.env.CAPTURE_ALL_CONVERSATIONS === 'true';
+const COSMOS_ENDPOINT = process.env.COSMOS_ENDPOINT;
+const COSMOS_KEY = process.env.COSMOS_KEY;
+const COSMOS_CONNECTION_STRING = process.env.COSMOS_CONNECTION_STRING;
+const COSMOS_DATABASE = process.env.COSMOS_DATABASE || 'fiona';
+const COSMOS_CONVERSATIONS_CONTAINER = process.env.COSMOS_CONVERSATIONS_CONTAINER || 'conversations';
+const DEPLOYMENT_TYPE = process.env.DEPLOYMENT_TYPE || 'local';
+
+// 360 days in seconds for per-document TTL
+const CONVERSATION_TTL_SECONDS = 31_104_000;
+
+/** @type {import('@azure/cosmos').Container | null} */
+let container = null;
+
+/** Tracks loggers that have already received the "not configured" warning. */
+const warnedLoggers = new WeakSet();
+
+/** Sentinel object used when no logger is supplied, to satisfy WeakSet's object requirement. */
+const nullLoggerSentinel = {};
+
+/**
+ * @param {{ warn?: (msg: string) => void } | null} [logger]
+ * @returns {Promise<import('@azure/cosmos').Container | null>}
+ */
+async function getContainer(logger) {
+  if (container) return container;
+
+  let client;
+  if (COSMOS_CONNECTION_STRING) {
+    client = new CosmosClient(COSMOS_CONNECTION_STRING);
+  } else if (COSMOS_ENDPOINT && COSMOS_KEY) {
+    client = new CosmosClient({ endpoint: COSMOS_ENDPOINT, key: COSMOS_KEY });
+  } else if (COSMOS_ENDPOINT) {
+    client = new CosmosClient({
+      endpoint: COSMOS_ENDPOINT,
+      aadCredentials: new DefaultAzureCredential(),
+    });
+  } else {
+    const key = logger ?? nullLoggerSentinel;
+    if (!warnedLoggers.has(key)) {
+      warnedLoggers.add(key);
+      logger?.warn?.(
+        'CosmosDB not configured — conversations will not be captured. Set COSMOS_CONNECTION_STRING or COSMOS_ENDPOINT.',
+      );
+    }
+    return null;
+  }
+
+  container = client.database(COSMOS_DATABASE).container(COSMOS_CONVERSATIONS_CONTAINER);
+  return container;
+}
+
+/**
+ * Capture a full conversation to Cosmos DB for human evaluation.
+ * No-ops silently when CAPTURE_ALL_CONVERSATIONS is false or Cosmos is unconfigured.
+ *
+ * @param {Object} capture
+ * @param {string} capture.userId - Slack user ID
+ * @param {string} [capture.teamId] - Slack workspace ID
+ * @param {string} capture.channelId - Slack channel ID
+ * @param {string} capture.threadTs - Thread timestamp (session identifier)
+ * @param {string} capture.messageTs - Message timestamp (event identifier)
+ * @param {string} capture.entryPoint - 'app_mention' or 'assistant_message'
+ * @param {string} capture.userMessage - The user's message text
+ * @param {string} capture.botResponse - The full bot response text
+ * @param {Array<{role: string, content: string}>} capture.threadHistory - Full thread context sent to LLM
+ * @param {string} capture.llmProvider - LLM provider name (e.g. 'perplexity')
+ * @param {string} capture.llmModel - LLM model name (e.g. 'sonar')
+ * @param {Array} [capture.sources] - Citation sources from metadata
+ * @param {{ warn?: (msg: string) => void }} [capture.logger] - Optional logger
+ */
+export async function captureConversation({
+  userId,
+  teamId,
+  channelId,
+  threadTs,
+  messageTs,
+  entryPoint,
+  userMessage,
+  botResponse,
+  threadHistory,
+  llmProvider,
+  llmModel,
+  sources,
+  logger,
+}) {
+  if (!CAPTURE_ALL_CONVERSATIONS) return;
+
+  const c = await getContainer(logger);
+  if (!c) return;
+
+  if (!userId || !channelId || !threadTs || !messageTs || !entryPoint) {
+    logger?.warn?.(
+      `Missing required fields for capturing conversation: ${JSON.stringify({ userId, channelId, threadTs, messageTs, entryPoint })}`,
+    );
+    return;
+  }
+
+  const doc = {
+    id: `${userId}_${threadTs}_${messageTs}`,
+    userId,
+    teamId,
+    channelId,
+    threadTs,
+    messageTs,
+    entryPoint,
+    userMessage,
+    botResponse,
+    threadHistory,
+    llmProvider,
+    llmModel,
+    sources: sources ?? [],
+    deploymentType: DEPLOYMENT_TYPE,
+    timestamp: new Date().toISOString(),
+    ttl: CONVERSATION_TTL_SECONDS,
+  };
+
+  try {
+    await c.items.upsert(doc, {
+      partitionKey: [doc.deploymentType, doc.userId],
+    });
+  } catch (error) {
+    logger?.warn?.(`Failed to capture conversation to Cosmos DB: ${error.message}`);
+  }
+}

--- a/apps/fiona-slack/src/agent/conversation-capture-store.js
+++ b/apps/fiona-slack/src/agent/conversation-capture-store.js
@@ -10,7 +10,7 @@ const CAPTURE_ALL_CONVERSATIONS = process.env.CAPTURE_ALL_CONVERSATIONS === 'tru
 const COSMOS_ENDPOINT = process.env.COSMOS_ENDPOINT;
 const COSMOS_KEY = process.env.COSMOS_KEY;
 const COSMOS_CONNECTION_STRING = process.env.COSMOS_CONNECTION_STRING;
-const COSMOS_DATABASE = process.env.COSMOS_DATABASE || 'fiona';
+const COSMOS_DATABASE = process.env.COSMOS_DATABASE || 'chatbot';
 const COSMOS_CONVERSATIONS_CONTAINER = process.env.COSMOS_CONVERSATIONS_CONTAINER || 'conversations';
 const DEPLOYMENT_TYPE = process.env.DEPLOYMENT_TYPE || 'local';
 

--- a/apps/fiona-slack/src/agent/conversation-capture-store.js
+++ b/apps/fiona-slack/src/agent/conversation-capture-store.js
@@ -127,6 +127,7 @@ export async function captureConversation({
       partitionKey: [doc.deploymentType, doc.userId],
     });
   } catch (error) {
-    logger?.warn?.(`Failed to capture conversation to Cosmos DB: ${error.message}`);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger?.warn?.(`Failed to capture conversation to Cosmos DB: ${errorMessage}`);
   }
 }

--- a/apps/fiona-slack/src/agent/conversation-capture-store.js
+++ b/apps/fiona-slack/src/agent/conversation-capture-store.js
@@ -20,11 +20,7 @@ const CONVERSATION_TTL_SECONDS = 31_104_000;
 /** @type {import('@azure/cosmos').Container | null} */
 let container = null;
 
-/** Tracks loggers that have already received the "not configured" warning. */
-const warnedLoggers = new WeakSet();
-
-/** Sentinel object used when no logger is supplied, to satisfy WeakSet's object requirement. */
-const nullLoggerSentinel = {};
+let warnedMissingConfig = false;
 
 /**
  * @param {{ warn?: (msg: string) => void } | null} [logger]
@@ -44,9 +40,8 @@ async function getContainer(logger) {
       aadCredentials: new DefaultAzureCredential(),
     });
   } else {
-    const key = logger ?? nullLoggerSentinel;
-    if (!warnedLoggers.has(key)) {
-      warnedLoggers.add(key);
+    if (!warnedMissingConfig) {
+      warnedMissingConfig = true;
       logger?.warn?.(
         'CosmosDB not configured — conversations will not be captured. Set COSMOS_CONNECTION_STRING or COSMOS_ENDPOINT.',
       );

--- a/apps/fiona-slack/src/agent/conversation-capture-store.js
+++ b/apps/fiona-slack/src/agent/conversation-capture-store.js
@@ -89,36 +89,36 @@ export async function captureConversation({
 }) {
   if (!CAPTURE_ALL_CONVERSATIONS) return;
 
-  const c = await getContainer(logger);
-  if (!c) return;
-
-  if (!userId || !channelId || !threadTs || !messageTs || !entryPoint) {
-    logger?.warn?.(
-      `Missing required fields for capturing conversation: ${JSON.stringify({ userId, channelId, threadTs, messageTs, entryPoint })}`,
-    );
-    return;
-  }
-
-  const doc = {
-    id: `${userId}_${threadTs}_${messageTs}`,
-    userId,
-    teamId,
-    channelId,
-    threadTs,
-    messageTs,
-    entryPoint,
-    userMessage,
-    botResponse,
-    threadHistory,
-    llmProvider,
-    llmModel,
-    sources: sources ?? [],
-    deploymentType: DEPLOYMENT_TYPE,
-    timestamp: new Date().toISOString(),
-    ttl: CONVERSATION_TTL_SECONDS,
-  };
-
   try {
+    const c = await getContainer(logger);
+    if (!c) return;
+
+    if (!userId || !channelId || !threadTs || !messageTs || !entryPoint) {
+      logger?.warn?.(
+        `Missing required fields for capturing conversation: ${JSON.stringify({ userId, channelId, threadTs, messageTs, entryPoint })}`,
+      );
+      return;
+    }
+
+    const doc = {
+      id: `${userId}_${threadTs}_${messageTs}`,
+      userId,
+      teamId,
+      channelId,
+      threadTs,
+      messageTs,
+      entryPoint,
+      userMessage,
+      botResponse,
+      threadHistory,
+      llmProvider,
+      llmModel,
+      sources: sources ?? [],
+      deploymentType: DEPLOYMENT_TYPE,
+      timestamp: new Date().toISOString(),
+      ttl: CONVERSATION_TTL_SECONDS,
+    };
+
     await c.items.upsert(doc, {
       partitionKey: [doc.deploymentType, doc.userId],
     });

--- a/apps/fiona-slack/src/agent/feedback-store.js
+++ b/apps/fiona-slack/src/agent/feedback-store.js
@@ -11,8 +11,6 @@ const COSMOS_KEY = process.env.COSMOS_KEY;
 const COSMOS_CONNECTION_STRING = process.env.COSMOS_CONNECTION_STRING;
 const COSMOS_DATABASE = process.env.COSMOS_DATABASE || 'chatbot';
 const COSMOS_CONTAINER = process.env.COSMOS_CONTAINER || 'feedback';
-const DEPLOYMENT_TYPE = process.env.DEPLOYMENT_TYPE || 'local';
-
 
 let warnedMissingConfig = false;
 const RETRYABLE_CODES = new Set([410, 429, 449, 500, 503]);

--- a/apps/fiona-slack/src/agent/feedback-store.js
+++ b/apps/fiona-slack/src/agent/feedback-store.js
@@ -3,15 +3,83 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import https from 'node:https';
-
 import { CosmosClient } from '@azure/cosmos';
 import { DefaultAzureCredential } from '@azure/identity';
 
+const COSMOS_ENDPOINT = process.env.COSMOS_ENDPOINT;
+const COSMOS_KEY = process.env.COSMOS_KEY;
+const COSMOS_CONNECTION_STRING = process.env.COSMOS_CONNECTION_STRING;
+const COSMOS_DATABASE = process.env.COSMOS_DATABASE || 'chatbot';
+const COSMOS_CONTAINER = process.env.COSMOS_CONTAINER || 'feedback';
+const DEPLOYMENT_TYPE = process.env.DEPLOYMENT_TYPE || 'local';
+
+
 let warnedMissingConfig = false;
+const RETRYABLE_CODES = new Set([410, 429, 449, 500, 503]);
+const RECONNECT_CODES = new Set([410, 503]);
 
 /** @type {import('@azure/cosmos').Container | null} */
 let container = null;
+
+/**
+ * @param {unknown} error
+ * @returns {string}
+ */
+function formatCosmosError(error) {
+  const fallback = error instanceof Error ? error.message : String(error);
+  const message = String(fallback || 'Unknown error')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const statusCode = Number(error?.statusCode);
+  const code = Number(error?.code);
+  const activityId = error?.activityId ?? error?.headers?.['x-ms-activity-id'];
+
+  const details = [
+    Number.isFinite(statusCode) ? `statusCode=${statusCode}` : null,
+    Number.isFinite(code) ? `code=${code}` : null,
+    activityId ? `activityId=${activityId}` : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  return details ? `${message} (${details})` : message;
+}
+
+/**
+ * @param {unknown} error
+ * @returns {number | null}
+ */
+function toNumericCode(error) {
+  const rawCode = error?.code ?? error?.statusCode;
+  const code = Number(rawCode);
+  if (Number.isFinite(code)) return code;
+
+  const message = String(error?.message ?? '').toLowerCase();
+  if (message.includes('410 response')) return 410;
+  if (message.includes('service is currently unavailable')) return 503;
+  return null;
+}
+
+function isEmulatorTarget() {
+  const target = `${COSMOS_CONNECTION_STRING ?? ''} ${COSMOS_ENDPOINT ?? ''}`.toLowerCase();
+  return target.includes('localhost') || target.includes('127.0.0.1');
+}
+
+function getRetryPolicy() {
+  if (process.env.NODE_ENV === 'test') {
+    return { maxAttempts: 2, baseDelayMs: 1, maxDelayMs: 5 };
+  }
+  if (isEmulatorTarget()) {
+    return { maxAttempts: 2, baseDelayMs: 200, maxDelayMs: 1000 };
+  }
+  return { maxAttempts: 3, baseDelayMs: 150, maxDelayMs: 800 };
+}
+
+function getDelayMs(policy, attempt) {
+  const baseDelay = Math.min(policy.baseDelayMs * 2 ** (attempt - 1), policy.maxDelayMs);
+  const jitter = Math.floor(Math.random() * Math.max(1, Math.floor(baseDelay * 0.2)));
+  return baseDelay + jitter;
+}
 
 /**
  * @param {{ warn?: (msg: string) => void }} [logger]
@@ -19,19 +87,18 @@ let container = null;
 async function getContainer(logger) {
   if (container) return container;
 
-  const connectionString = process.env.COSMOS_CONNECTION_STRING;
-  const endpoint = process.env.COSMOS_ENDPOINT;
-  const key = process.env.COSMOS_KEY;
-  const database = process.env.COSMOS_DATABASE || 'chatbot';
-  const cosmosContainer = process.env.COSMOS_CONTAINER || 'feedback';
-
+  const database = COSMOS_DATABASE;
+  const cosmosContainer = COSMOS_CONTAINER;
   let client;
-  if (connectionString) {
-    client = new CosmosClient({ connectionString });
-  } else if (endpoint && key) {
-    client = new CosmosClient({ endpoint, key });
-  } else if (endpoint) {
-    client = new CosmosClient({ endpoint, aadCredentials: new DefaultAzureCredential() });
+  if (COSMOS_CONNECTION_STRING) {
+    client = new CosmosClient(COSMOS_CONNECTION_STRING);
+  } else if (COSMOS_ENDPOINT && COSMOS_KEY) {
+    client = new CosmosClient({ endpoint: COSMOS_ENDPOINT, key: COSMOS_KEY });
+  } else if (COSMOS_ENDPOINT) {
+    client = new CosmosClient({
+      endpoint: COSMOS_ENDPOINT,
+      aadCredentials: new DefaultAzureCredential(),
+    });
   } else {
     if (!warnedMissingConfig) {
       warnedMissingConfig = true;
@@ -101,11 +168,26 @@ export async function recordFeedback({
     timestamp: new Date().toISOString(),
   };
 
-  try {
-    await c.items.upsert(doc, {
-      partitionKey: [doc.deploymentType, doc.feedbackId],
-    });
-  } catch (error) {
-    logger?.warn?.(`Failed to record feedback to Cosmos DB: ${error.message}`);
+  const policy = getRetryPolicy();
+  for (let attempt = 1; attempt <= policy.maxAttempts; attempt++) {
+    try {
+      const activeContainer = attempt === 1 ? c : await getContainer(logger);
+      if (!activeContainer) return;
+      await activeContainer.items.upsert(doc, {
+        partitionKey: [doc.deploymentType, doc.feedbackId],
+      });
+      return;
+    } catch (error) {
+      const code = toNumericCode(error);
+      const retryable = RETRYABLE_CODES.has(code);
+      if (!retryable || attempt === policy.maxAttempts) {
+        logger?.warn?.(`Failed to record feedback to Cosmos DB: ${formatCosmosError(error)}`);
+        return;
+      }
+      if (RECONNECT_CODES.has(code)) {
+        container = null;
+      }
+      await new Promise((resolve) => setTimeout(resolve, getDelayMs(policy, attempt)));
+    }
   }
 }

--- a/apps/fiona-slack/src/agent/feedback-store.js
+++ b/apps/fiona-slack/src/agent/feedback-store.js
@@ -3,6 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import https from 'node:https';
+
 import { CosmosClient } from '@azure/cosmos';
 import { DefaultAzureCredential } from '@azure/identity';
 

--- a/apps/fiona-slack/src/agent/interaction-store.js
+++ b/apps/fiona-slack/src/agent/interaction-store.js
@@ -3,8 +3,6 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import https from 'node:https';
-
 import { CosmosClient } from '@azure/cosmos';
 import { DefaultAzureCredential } from '@azure/identity';
 
@@ -15,9 +13,71 @@ const COSMOS_DATABASE = process.env.COSMOS_DATABASE || 'chatbot';
 const COSMOS_CONTAINER = process.env.COSMOS_INTERACTIONS_CONTAINER || 'interactions';
 
 let warnedMissingConfig = false;
+const RETRYABLE_CODES = new Set([410, 429, 449, 500, 503]);
+const RECONNECT_CODES = new Set([410, 503]);
 
 /** @type {import('@azure/cosmos').Container | null} */
 let container = null;
+
+/**
+ * @param {unknown} error
+ * @returns {string}
+ */
+function formatCosmosError(error) {
+  const fallback = error instanceof Error ? error.message : String(error);
+  const message = String(fallback || 'Unknown error')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const statusCode = Number(error?.statusCode);
+  const code = Number(error?.code);
+  const activityId = error?.activityId ?? error?.headers?.['x-ms-activity-id'];
+
+  const details = [
+    Number.isFinite(statusCode) ? `statusCode=${statusCode}` : null,
+    Number.isFinite(code) ? `code=${code}` : null,
+    activityId ? `activityId=${activityId}` : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  return details ? `${message} (${details})` : message;
+}
+
+/**
+ * @param {unknown} error
+ * @returns {number | null}
+ */
+function toNumericCode(error) {
+  const rawCode = error?.code ?? error?.statusCode;
+  const code = Number(rawCode);
+  if (Number.isFinite(code)) return code;
+
+  const message = String(error?.message ?? '').toLowerCase();
+  if (message.includes('410 response')) return 410;
+  if (message.includes('service is currently unavailable')) return 503;
+  return null;
+}
+
+function isEmulatorTarget() {
+  const target = `${COSMOS_CONNECTION_STRING ?? ''} ${COSMOS_ENDPOINT ?? ''}`.toLowerCase();
+  return target.includes('localhost') || target.includes('127.0.0.1');
+}
+
+function getRetryPolicy() {
+  if (process.env.NODE_ENV === 'test') {
+    return { maxAttempts: 2, baseDelayMs: 1, maxDelayMs: 5 };
+  }
+  if (isEmulatorTarget()) {
+    return { maxAttempts: 2, baseDelayMs: 200, maxDelayMs: 1000 };
+  }
+  return { maxAttempts: 3, baseDelayMs: 150, maxDelayMs: 800 };
+}
+
+function getDelayMs(policy, attempt) {
+  const baseDelay = Math.min(policy.baseDelayMs * 2 ** (attempt - 1), policy.maxDelayMs);
+  const jitter = Math.floor(Math.random() * Math.max(1, Math.floor(baseDelay * 0.2)));
+  return baseDelay + jitter;
+}
 
 /**
  * Get or initialize the Cosmos DB container for interactions.
@@ -33,17 +93,15 @@ export async function getContainer(logger) {
   const database = COSMOS_DATABASE;
   const cosmosContainer = COSMOS_CONTAINER;
 
-  const tlsAgent = new https.Agent({ rejectUnauthorized: false });
   let client;
   if (connectionString) {
-    client = new CosmosClient({ connectionString, agent: tlsAgent });
+    client = new CosmosClient({ connectionString });
   } else if (endpoint && key) {
-    client = new CosmosClient({ endpoint, key, agent: tlsAgent });
+    client = new CosmosClient({ endpoint, key });
   } else if (endpoint) {
     client = new CosmosClient({
       endpoint,
       aadCredentials: new DefaultAzureCredential(),
-      agent: tlsAgent,
     });
   } else {
     if (!warnedMissingConfig) {
@@ -129,11 +187,26 @@ export async function recordInteraction({
     timestamp: new Date().toISOString(),
   };
 
-  try {
-    await c.items.upsert(doc, {
-      partitionKey: [doc.deploymentType, doc.userId],
-    });
-  } catch (error) {
-    logger?.warn?.(`Failed to record interaction to Cosmos DB: ${error.message}`);
+  const policy = getRetryPolicy();
+  for (let attempt = 1; attempt <= policy.maxAttempts; attempt++) {
+    try {
+      const activeContainer = attempt === 1 ? c : await getContainer(logger);
+      if (!activeContainer) return;
+      await activeContainer.items.upsert(doc, {
+        partitionKey: [doc.deploymentType, doc.userId],
+      });
+      return;
+    } catch (error) {
+      const code = toNumericCode(error);
+      const retryable = RETRYABLE_CODES.has(code);
+      if (!retryable || attempt === policy.maxAttempts) {
+        logger?.warn?.(`Failed to record interaction to Cosmos DB: ${formatCosmosError(error)}`);
+        return;
+      }
+      if (RECONNECT_CODES.has(code)) {
+        container = null;
+      }
+      await new Promise((resolve) => setTimeout(resolve, getDelayMs(policy, attempt)));
+    }
   }
 }

--- a/apps/fiona-slack/src/agent/interaction-store.js
+++ b/apps/fiona-slack/src/agent/interaction-store.js
@@ -3,6 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import https from 'node:https';
+
 import { CosmosClient } from '@azure/cosmos';
 import { DefaultAzureCredential } from '@azure/identity';
 
@@ -31,15 +33,17 @@ export async function getContainer(logger) {
   const database = COSMOS_DATABASE;
   const cosmosContainer = COSMOS_CONTAINER;
 
+  const tlsAgent = new https.Agent({ rejectUnauthorized: false });
   let client;
   if (connectionString) {
-    client = new CosmosClient({ connectionString });
+    client = new CosmosClient({ connectionString, agent: tlsAgent });
   } else if (endpoint && key) {
-    client = new CosmosClient({ endpoint, key });
+    client = new CosmosClient({ endpoint, key, agent: tlsAgent });
   } else if (endpoint) {
     client = new CosmosClient({
       endpoint,
       aadCredentials: new DefaultAzureCredential(),
+      agent: tlsAgent,
     });
   } else {
     if (!warnedMissingConfig) {

--- a/apps/fiona-slack/src/agent/llm-caller.js
+++ b/apps/fiona-slack/src/agent/llm-caller.js
@@ -432,7 +432,7 @@ export async function callPerplexityChat(streamer, prompts) {
  * @param {Array} prompts - OpenAI-style message array
  * @param {import("@slack/logger").Logger} logger - Logger instance
  *
- * @returns {Promise<MetadataEnvelope>} Metadata envelope with citation metadata
+ * @returns {Promise<{ metadata: MetadataEnvelope, botText: string }>} Metadata envelope and full bot response text
  *
  * @see {@link https://docs.slack.dev/tools/bolt-js/web#sending-streaming-messages}
  */

--- a/apps/fiona-slack/src/agent/llm-caller.js
+++ b/apps/fiona-slack/src/agent/llm-caller.js
@@ -16,6 +16,7 @@ import { normalizeSources } from './utils/source-normalizer.js';
 const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY;
 const PERPLEXITY_API_MODEL = process.env.PERPLEXITY_API_MODEL || 'sonar';
 export const LLM_MODEL = PERPLEXITY_API_MODEL;
+export const SYSTEM_PROMPT_VERSION = process.env.SYSTEM_PROMPT_VERSION || 'v1';
 const PERPLEXITY_DOMAIN_FILTER = process.env.PERPLEXITY_DOMAIN_FILTER
   ? process.env.PERPLEXITY_DOMAIN_FILTER.split(',').map((d) => d.trim())
   : ['www.ed-fi.org', 'docs.ed-fi.org'];
@@ -432,7 +433,7 @@ export async function callPerplexityChat(streamer, prompts) {
  * @param {Array} prompts - OpenAI-style message array
  * @param {import("@slack/logger").Logger} logger - Logger instance
  *
- * @returns {Promise<{ metadata: MetadataEnvelope, botText: string }>} Metadata envelope and full bot response text
+ * @returns {Promise<{ metadata: MetadataEnvelope, botText: string, systemPromptVersion: string }>} Metadata envelope and full bot response text
  *
  * @see {@link https://docs.slack.dev/tools/bolt-js/web#sending-streaming-messages}
  */
@@ -481,5 +482,5 @@ export async function callLLM(streamer, prompts, logger) {
     throw error;
   }
 
-  return { metadata, botText };
+  return { metadata, botText, systemPromptVersion: SYSTEM_PROMPT_VERSION };
 }

--- a/apps/fiona-slack/src/agent/llm-caller.js
+++ b/apps/fiona-slack/src/agent/llm-caller.js
@@ -348,7 +348,7 @@ function linkifyCitationMarkers(text, sourceIndexMap = {}) {
  *
  * @param {import("@slack/web-api").ChatStreamer} streamer
  * @param {Array} prompts
- * @returns {Promise<string[]>} Citation URL strings (may be empty)
+ * @returns {Promise<{ botText: string, citations: string[] }>} Full response text and citation URL strings
  */
 export async function callPerplexityChat(streamer, prompts) {
   if (!perplexityClient) {

--- a/apps/fiona-slack/src/agent/llm-caller.js
+++ b/apps/fiona-slack/src/agent/llm-caller.js
@@ -15,6 +15,7 @@ import { normalizeSources } from './utils/source-normalizer.js';
 // ─── Perplexity Configuration ───────────────────────────────────────────────
 const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY;
 const PERPLEXITY_API_MODEL = process.env.PERPLEXITY_API_MODEL || 'sonar';
+export const LLM_MODEL = PERPLEXITY_API_MODEL;
 const PERPLEXITY_DOMAIN_FILTER = process.env.PERPLEXITY_DOMAIN_FILTER
   ? process.env.PERPLEXITY_DOMAIN_FILTER.split(',').map((d) => d.trim())
   : ['www.ed-fi.org', 'docs.ed-fi.org'];
@@ -412,13 +413,14 @@ export async function callPerplexityChat(streamer, prompts) {
   // Linkify [n] markers using the now-populated source_index_map, then emit
   // a single append call.  Skipping the append entirely when there is no text
   // avoids sending an empty markdown block to Slack.
+  let botText = '';
   if (textBuffer) {
     const sourceIndexMap = streamer?.__citation_metadata?.source_index_map || {};
-    const linkifiedText = linkifyCitationMarkers(textBuffer, sourceIndexMap);
-    await streamer.append({ markdown_text: linkifiedText });
+    botText = linkifyCitationMarkers(textBuffer, sourceIndexMap);
+    await streamer.append({ markdown_text: botText });
   }
 
-  return citations;
+  return { botText, citations };
 }
 
 // ─── Main Entry Point ─────────────────────────────────────────────────────
@@ -446,8 +448,9 @@ export async function callLLM(streamer, prompts, logger) {
 
   const metadataWaitStart = Date.now();
 
+  let botText = '';
   try {
-    await callPerplexityChat(streamer, [{ role: 'system', content: SYSTEM_PROMPT }, ...prompts]);
+    ({ botText } = await callPerplexityChat(streamer, [{ role: 'system', content: SYSTEM_PROMPT }, ...prompts]));
 
     // Gate finalization: transition to READY_TO_FINALIZE from any pre-finalize state once
     // the LLM call has completed synchronously.
@@ -478,5 +481,5 @@ export async function callLLM(streamer, prompts, logger) {
     throw error;
   }
 
-  return metadata;
+  return { metadata, botText };
 }

--- a/apps/fiona-slack/src/listeners/assistant/message.js
+++ b/apps/fiona-slack/src/listeners/assistant/message.js
@@ -5,7 +5,13 @@
 
 import { captureConversation } from '../../agent/conversation-capture-store.js';
 import { handleInteractionWithTelemetry, sleep, waitForMetadataReady } from '../../agent/interaction-telemetry.js';
-import { CITATION_POLICY, callLLM, finalizeMetadataEnvelope, LLM_MODEL } from '../../agent/llm-caller.js';
+import {
+  CITATION_POLICY,
+  callLLM,
+  finalizeMetadataEnvelope,
+  LLM_MODEL,
+  SYSTEM_PROMPT_VERSION,
+} from '../../agent/llm-caller.js';
 import { handleRateLimitedInteraction } from '../../agent/rate-limited-handler.js';
 import { buildThreadHistory } from '../../agent/thread-history.js';
 import { generateResponseId, shouldFinalize } from '../../agent/utils/idempotent-finalize.js';
@@ -208,7 +214,7 @@ export const message = async ({ client, context, logger, message, say, setStatus
 
         const prompts = await buildThreadHistory(client, channel, thread_ts, { currentText: text, logger });
 
-        const { metadata, botText } = await callLLM(streamer, prompts, logger);
+        const { metadata, botText, systemPromptVersion } = await callLLM(streamer, prompts, logger);
 
         // Guard against duplicate finalization
         const responseId = generateResponseId(channel, thread_ts, message.ts);
@@ -240,6 +246,7 @@ export const message = async ({ client, context, logger, message, say, setStatus
           threadHistory: prompts,
           llmProvider: metadata?.provider ?? 'perplexity',
           llmModel: LLM_MODEL,
+          systemPromptVersion: systemPromptVersion ?? SYSTEM_PROMPT_VERSION,
           sources: metadata?.sources,
           logger,
         });

--- a/apps/fiona-slack/src/listeners/assistant/message.js
+++ b/apps/fiona-slack/src/listeners/assistant/message.js
@@ -207,7 +207,7 @@ export const message = async ({ client, context, logger, message, say, setStatus
 
         const prompts = await buildThreadHistory(client, channel, thread_ts, { currentText: text, logger });
 
-        const metadata = await callLLM(streamer, prompts, logger);
+        const { metadata, botText } = await callLLM(streamer, prompts, logger);
 
         // Guard against duplicate finalization
         const responseId = generateResponseId(channel, thread_ts, message.ts);

--- a/apps/fiona-slack/src/listeners/assistant/message.js
+++ b/apps/fiona-slack/src/listeners/assistant/message.js
@@ -4,11 +4,12 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import { handleInteractionWithTelemetry, sleep, waitForMetadataReady } from '../../agent/interaction-telemetry.js';
-import { CITATION_POLICY, callLLM, finalizeMetadataEnvelope } from '../../agent/llm-caller.js';
+import { CITATION_POLICY, callLLM, finalizeMetadataEnvelope, LLM_MODEL } from '../../agent/llm-caller.js';
 import { handleRateLimitedInteraction } from '../../agent/rate-limited-handler.js';
 import { buildThreadHistory } from '../../agent/thread-history.js';
 import { generateResponseId, shouldFinalize } from '../../agent/utils/idempotent-finalize.js';
 import { feedbackBlock } from '../views/feedback_block.js';
+import { captureConversation } from '../../agent/conversation-capture-store.js';
 
 /**
  * Handles when users send messages or select a prompt in an assistant thread
@@ -226,6 +227,22 @@ export const message = async ({ client, context, logger, message, say, setStatus
 
         await streamer.stop({ blocks: [feedbackBlock] });
         finalizeMetadataEnvelope(metadata);
+
+        await captureConversation({
+          userId,
+          teamId,
+          channelId: channel,
+          threadTs: thread_ts,
+          messageTs,
+          entryPoint: 'assistant_message',
+          userMessage: text,
+          botResponse: botText,
+          threadHistory: prompts,
+          llmProvider: metadata?.provider ?? 'perplexity',
+          llmModel: LLM_MODEL,
+          sources: metadata?.sources,
+          logger,
+        });
       }
     },
   );

--- a/apps/fiona-slack/src/listeners/assistant/message.js
+++ b/apps/fiona-slack/src/listeners/assistant/message.js
@@ -3,13 +3,13 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import { captureConversation } from '../../agent/conversation-capture-store.js';
 import { handleInteractionWithTelemetry, sleep, waitForMetadataReady } from '../../agent/interaction-telemetry.js';
 import { CITATION_POLICY, callLLM, finalizeMetadataEnvelope, LLM_MODEL } from '../../agent/llm-caller.js';
 import { handleRateLimitedInteraction } from '../../agent/rate-limited-handler.js';
 import { buildThreadHistory } from '../../agent/thread-history.js';
 import { generateResponseId, shouldFinalize } from '../../agent/utils/idempotent-finalize.js';
 import { feedbackBlock } from '../views/feedback_block.js';
-import { captureConversation } from '../../agent/conversation-capture-store.js';
 
 /**
  * Handles when users send messages or select a prompt in an assistant thread

--- a/apps/fiona-slack/src/listeners/events/app_mention.js
+++ b/apps/fiona-slack/src/listeners/events/app_mention.js
@@ -5,7 +5,13 @@
 
 import { captureConversation } from '../../agent/conversation-capture-store.js';
 import { handleInteractionWithTelemetry, waitForMetadataReady } from '../../agent/interaction-telemetry.js';
-import { CITATION_POLICY, callLLM, finalizeMetadataEnvelope, LLM_MODEL } from '../../agent/llm-caller.js';
+import {
+  CITATION_POLICY,
+  callLLM,
+  finalizeMetadataEnvelope,
+  LLM_MODEL,
+  SYSTEM_PROMPT_VERSION,
+} from '../../agent/llm-caller.js';
 import { handleRateLimitedInteraction } from '../../agent/rate-limited-handler.js';
 import { buildThreadHistory } from '../../agent/thread-history.js';
 import { generateResponseId, shouldFinalize } from '../../agent/utils/idempotent-finalize.js';
@@ -91,7 +97,7 @@ export const appMentionCallback = async ({ event, client, logger, say }) => {
 
       const prompts = await buildThreadHistory(client, channel, thread_ts, { currentText: text, logger });
 
-      const { metadata, botText } = await callLLM(streamer, prompts, logger);
+      const { metadata, botText, systemPromptVersion } = await callLLM(streamer, prompts, logger);
 
       // Guard against duplicate finalization
       const responseId = generateResponseId(channel, thread_ts, event.ts);
@@ -123,6 +129,7 @@ export const appMentionCallback = async ({ event, client, logger, say }) => {
         threadHistory: prompts,
         llmProvider: metadata?.provider ?? 'perplexity',
         llmModel: LLM_MODEL,
+        systemPromptVersion: systemPromptVersion ?? SYSTEM_PROMPT_VERSION,
         sources: metadata?.sources,
         logger,
       });

--- a/apps/fiona-slack/src/listeners/events/app_mention.js
+++ b/apps/fiona-slack/src/listeners/events/app_mention.js
@@ -3,13 +3,13 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import { captureConversation } from '../../agent/conversation-capture-store.js';
 import { handleInteractionWithTelemetry, waitForMetadataReady } from '../../agent/interaction-telemetry.js';
 import { CITATION_POLICY, callLLM, finalizeMetadataEnvelope, LLM_MODEL } from '../../agent/llm-caller.js';
 import { handleRateLimitedInteraction } from '../../agent/rate-limited-handler.js';
 import { buildThreadHistory } from '../../agent/thread-history.js';
 import { generateResponseId, shouldFinalize } from '../../agent/utils/idempotent-finalize.js';
 import { feedbackBlock } from '../views/feedback_block.js';
-import { captureConversation } from '../../agent/conversation-capture-store.js';
 
 /**
  * Handles the event when the app is mentioned in a Slack conversation

--- a/apps/fiona-slack/src/listeners/events/app_mention.js
+++ b/apps/fiona-slack/src/listeners/events/app_mention.js
@@ -90,7 +90,7 @@ export const appMentionCallback = async ({ event, client, logger, say }) => {
 
       const prompts = await buildThreadHistory(client, channel, thread_ts, { currentText: text, logger });
 
-      const metadata = await callLLM(streamer, prompts, logger);
+      const { metadata, botText } = await callLLM(streamer, prompts, logger);
 
       // Guard against duplicate finalization
       const responseId = generateResponseId(channel, thread_ts, event.ts);

--- a/apps/fiona-slack/src/listeners/events/app_mention.js
+++ b/apps/fiona-slack/src/listeners/events/app_mention.js
@@ -4,11 +4,12 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import { handleInteractionWithTelemetry, waitForMetadataReady } from '../../agent/interaction-telemetry.js';
-import { CITATION_POLICY, callLLM, finalizeMetadataEnvelope } from '../../agent/llm-caller.js';
+import { CITATION_POLICY, callLLM, finalizeMetadataEnvelope, LLM_MODEL } from '../../agent/llm-caller.js';
 import { handleRateLimitedInteraction } from '../../agent/rate-limited-handler.js';
 import { buildThreadHistory } from '../../agent/thread-history.js';
 import { generateResponseId, shouldFinalize } from '../../agent/utils/idempotent-finalize.js';
 import { feedbackBlock } from '../views/feedback_block.js';
+import { captureConversation } from '../../agent/conversation-capture-store.js';
 
 /**
  * Handles the event when the app is mentioned in a Slack conversation
@@ -109,6 +110,22 @@ export const appMentionCallback = async ({ event, client, logger, say }) => {
 
       await streamer.stop({ blocks: [feedbackBlock] });
       finalizeMetadataEnvelope(metadata);
+
+      await captureConversation({
+        userId: user,
+        teamId: team,
+        channelId: channel,
+        threadTs: thread_ts,
+        messageTs,
+        entryPoint: 'app_mention',
+        userMessage: text,
+        botResponse: botText,
+        threadHistory: prompts,
+        llmProvider: metadata?.provider ?? 'perplexity',
+        llmModel: LLM_MODEL,
+        sources: metadata?.sources,
+        logger,
+      });
     },
   );
 };

--- a/apps/fiona-slack/tests/agent/conversation-capture-store.test.js
+++ b/apps/fiona-slack/tests/agent/conversation-capture-store.test.js
@@ -3,7 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import { describe, it, expect, jest, beforeAll, afterAll, beforeEach } from '@jest/globals';
+import { describe, it, expect, jest, beforeAll, afterAll, beforeEach, afterEach } from '@jest/globals';
 
 const mockUpsert = jest.fn().mockResolvedValue({});
 const mockContainerObj = { items: { upsert: mockUpsert } };
@@ -32,6 +32,7 @@ const VALID_CAPTURE = {
   threadHistory: [{ role: 'user', content: 'What is Ed-Fi?' }],
   llmProvider: 'perplexity',
   llmModel: 'sonar',
+  systemPromptVersion: 'v1',
   sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs', index: 1 }],
 };
 
@@ -48,6 +49,16 @@ describe('conversation-capture-store - CAPTURE_ALL_CONVERSATIONS disabled', () =
 
   it('is a no-op when CAPTURE_ALL_CONVERSATIONS is not set', async () => {
     await captureConversation(VALID_CAPTURE);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when CAPTURE_ALL_CONVERSATIONS is set to 'false'", async () => {
+    process.env.CAPTURE_ALL_CONVERSATIONS = 'false';
+    jest.resetModules();
+    const { captureConversation: captureConversationWithFalseFlag } = await import(
+      '../../src/agent/conversation-capture-store.js'
+    );
+    await captureConversationWithFalseFlag(VALID_CAPTURE);
     expect(mockUpsert).not.toHaveBeenCalled();
   });
 });
@@ -103,6 +114,16 @@ describe('conversation-capture-store - Cosmos configured via connection string',
 
   beforeEach(() => {
     mockUpsert.mockClear();
+    mockDatabase.container.mockClear();
+    MockCosmosClient.mockClear();
+    jest.spyOn(global, 'setTimeout').mockImplementation((fn) => {
+      fn();
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('upserts a document with all required fields', async () => {
@@ -122,9 +143,10 @@ describe('conversation-capture-store - Cosmos configured via connection string',
     expect(doc.threadHistory).toEqual([{ role: 'user', content: 'What is Ed-Fi?' }]);
     expect(doc.llmProvider).toBe('perplexity');
     expect(doc.llmModel).toBe('sonar');
+    expect(doc.systemPromptVersion).toBe('v1');
     expect(doc.sources).toEqual([{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs', index: 1 }]);
     expect(doc.deploymentType).toBe('local');
-    expect(doc.ttl).toBe(31_104_000);
+    expect(doc.ttl).toBe(15_552_000);
     expect(doc.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
@@ -140,6 +162,12 @@ describe('conversation-capture-store - Cosmos configured via connection string',
     expect(doc.sources).toEqual([]);
   });
 
+  it('defaults systemPromptVersion to unknown when not provided', async () => {
+    await captureConversation({ ...VALID_CAPTURE, systemPromptVersion: undefined });
+    const [doc] = mockUpsert.mock.calls[0];
+    expect(doc.systemPromptVersion).toBe('unknown');
+  });
+
   it('silently swallows Cosmos write errors and warns', async () => {
     mockUpsert.mockRejectedValueOnce(new Error('cosmos timeout'));
     const logger = { warn: jest.fn() };
@@ -151,6 +179,81 @@ describe('conversation-capture-store - Cosmos configured via connection string',
     const logger = { warn: jest.fn() };
     await captureConversation({ ...VALID_CAPTURE, userId: undefined, logger });
     expect(mockUpsert).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Missing required fields'));
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Missing required fields for capturing conversation: userId',
+    );
+  });
+
+  it('retries once for retryable 429 responses and then succeeds', async () => {
+    mockUpsert.mockRejectedValueOnce({ statusCode: 429 }).mockResolvedValueOnce({});
+
+    await captureConversation(VALID_CAPTURE);
+
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry for non-retryable responses', async () => {
+    mockUpsert.mockRejectedValueOnce({ statusCode: 400 });
+    const logger = { warn: jest.fn() };
+
+    await captureConversation({ ...VALID_CAPTURE, logger });
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('statusCode=400'));
+  });
+
+  it('retries up to max attempts for retryable failures', async () => {
+    mockUpsert.mockRejectedValue({ statusCode: 503 });
+    const logger = { warn: jest.fn() };
+
+    await captureConversation({ ...VALID_CAPTURE, logger });
+
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('statusCode=503'));
+  });
+
+  it('resets cached container and reconnects on 410 before retry', async () => {
+    mockUpsert.mockRejectedValueOnce({ statusCode: 410 }).mockResolvedValueOnce({});
+    const containerCallsBefore = mockDatabase.container.mock.calls.length;
+    const clientCallsBefore = MockCosmosClient.mock.calls.length;
+
+    await captureConversation(VALID_CAPTURE);
+
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
+    expect(mockDatabase.container.mock.calls.length).toBeGreaterThan(containerCallsBefore);
+    expect(MockCosmosClient.mock.calls.length).toBeGreaterThan(clientCallsBefore);
+  });
+});
+
+describe('conversation-capture-store - production auth guard', () => {
+  let captureConversation;
+
+  beforeAll(async () => {
+    process.env.CAPTURE_ALL_CONVERSATIONS = 'true';
+    process.env.COSMOS_ENDPOINT = 'https://prod.documents.azure.com:443/';
+    process.env.COSMOS_KEY = 'secret-key';
+    process.env.DEPLOYMENT_TYPE = 'production';
+    delete process.env.COSMOS_CONNECTION_STRING;
+    jest.resetModules();
+    mockUpsert.mockClear();
+    ({ captureConversation } = await import('../../src/agent/conversation-capture-store.js'));
+  });
+
+  afterAll(() => {
+    delete process.env.CAPTURE_ALL_CONVERSATIONS;
+    delete process.env.COSMOS_ENDPOINT;
+    delete process.env.COSMOS_KEY;
+    delete process.env.DEPLOYMENT_TYPE;
+  });
+
+  it('warns and skips writes when COSMOS_KEY auth is configured in production', async () => {
+    const logger = { warn: jest.fn() };
+
+    await captureConversation({ ...VALID_CAPTURE, logger });
+
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('does not support COSMOS_KEY auth in production'),
+    );
   });
 });

--- a/apps/fiona-slack/tests/agent/conversation-capture-store.test.js
+++ b/apps/fiona-slack/tests/agent/conversation-capture-store.test.js
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { describe, it, expect, jest, beforeAll, afterAll, beforeEach } from '@jest/globals';
+
+const mockUpsert = jest.fn().mockResolvedValue({});
+const mockContainerObj = { items: { upsert: mockUpsert } };
+const mockDatabase = { container: jest.fn().mockReturnValue(mockContainerObj) };
+const MockCosmosClient = jest.fn().mockImplementation(() => ({
+  database: jest.fn().mockReturnValue(mockDatabase),
+}));
+
+jest.unstable_mockModule('@azure/cosmos', () => ({
+  CosmosClient: MockCosmosClient,
+}));
+
+jest.unstable_mockModule('@azure/identity', () => ({
+  DefaultAzureCredential: jest.fn(),
+}));
+
+const VALID_CAPTURE = {
+  userId: 'U123',
+  teamId: 'T456',
+  channelId: 'C789',
+  threadTs: '1000.0001',
+  messageTs: '1000.0002',
+  entryPoint: 'app_mention',
+  userMessage: 'What is Ed-Fi?',
+  botResponse: 'Ed-Fi is a data standard.',
+  threadHistory: [{ role: 'user', content: 'What is Ed-Fi?' }],
+  llmProvider: 'perplexity',
+  llmModel: 'sonar',
+  sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs', index: 1 }],
+};
+
+describe('conversation-capture-store - CAPTURE_ALL_CONVERSATIONS disabled', () => {
+  let captureConversation;
+
+  beforeAll(async () => {
+    delete process.env.CAPTURE_ALL_CONVERSATIONS;
+    delete process.env.COSMOS_ENDPOINT;
+    delete process.env.COSMOS_CONNECTION_STRING;
+    delete process.env.COSMOS_CONVERSATIONS_CONTAINER;
+    ({ captureConversation } = await import('../../src/agent/conversation-capture-store.js'));
+  });
+
+  it('is a no-op when CAPTURE_ALL_CONVERSATIONS is not set', async () => {
+    await captureConversation(VALID_CAPTURE);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('conversation-capture-store - Cosmos not configured', () => {
+  let captureConversation;
+
+  beforeAll(async () => {
+    process.env.CAPTURE_ALL_CONVERSATIONS = 'true';
+    delete process.env.COSMOS_ENDPOINT;
+    delete process.env.COSMOS_CONNECTION_STRING;
+    delete process.env.COSMOS_CONVERSATIONS_CONTAINER;
+    jest.resetModules();
+    ({ captureConversation } = await import('../../src/agent/conversation-capture-store.js'));
+  });
+
+  afterAll(() => {
+    delete process.env.CAPTURE_ALL_CONVERSATIONS;
+  });
+
+  it('is a no-op and warns once when Cosmos is not configured', async () => {
+    const logger = { warn: jest.fn() };
+    await captureConversation({ ...VALID_CAPTURE, logger });
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('CosmosDB not configured'));
+  });
+
+  it('warns only once across multiple calls', async () => {
+    const logger = { warn: jest.fn() };
+    await captureConversation({ ...VALID_CAPTURE, logger });
+    await captureConversation({ ...VALID_CAPTURE, logger });
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('conversation-capture-store - Cosmos configured via connection string', () => {
+  let captureConversation;
+
+  beforeAll(async () => {
+    process.env.CAPTURE_ALL_CONVERSATIONS = 'true';
+    process.env.COSMOS_CONNECTION_STRING = 'AccountEndpoint=https://test.documents.azure.com:443/;AccountKey=dGVzdA==';
+    process.env.COSMOS_CONVERSATIONS_CONTAINER = 'conversations';
+    process.env.DEPLOYMENT_TYPE = 'local';
+    jest.resetModules();
+    MockCosmosClient.mockClear();
+    mockUpsert.mockClear();
+    ({ captureConversation } = await import('../../src/agent/conversation-capture-store.js'));
+  });
+
+  afterAll(() => {
+    delete process.env.CAPTURE_ALL_CONVERSATIONS;
+    delete process.env.COSMOS_CONNECTION_STRING;
+    delete process.env.COSMOS_CONVERSATIONS_CONTAINER;
+  });
+
+  beforeEach(() => {
+    mockUpsert.mockClear();
+  });
+
+  it('upserts a document with all required fields', async () => {
+    await captureConversation(VALID_CAPTURE);
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const [doc] = mockUpsert.mock.calls[0];
+    expect(doc.id).toBe('U123_1000.0001_1000.0002');
+    expect(doc.userId).toBe('U123');
+    expect(doc.teamId).toBe('T456');
+    expect(doc.channelId).toBe('C789');
+    expect(doc.threadTs).toBe('1000.0001');
+    expect(doc.messageTs).toBe('1000.0002');
+    expect(doc.entryPoint).toBe('app_mention');
+    expect(doc.userMessage).toBe('What is Ed-Fi?');
+    expect(doc.botResponse).toBe('Ed-Fi is a data standard.');
+    expect(doc.threadHistory).toEqual([{ role: 'user', content: 'What is Ed-Fi?' }]);
+    expect(doc.llmProvider).toBe('perplexity');
+    expect(doc.llmModel).toBe('sonar');
+    expect(doc.sources).toEqual([{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs', index: 1 }]);
+    expect(doc.deploymentType).toBe('local');
+    expect(doc.ttl).toBe(31_104_000);
+    expect(doc.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('uses deploymentType and userId as the partition key', async () => {
+    await captureConversation(VALID_CAPTURE);
+    const [, options] = mockUpsert.mock.calls[0];
+    expect(options.partitionKey).toEqual(['local', 'U123']);
+  });
+
+  it('defaults sources to empty array when not provided', async () => {
+    await captureConversation({ ...VALID_CAPTURE, sources: undefined });
+    const [doc] = mockUpsert.mock.calls[0];
+    expect(doc.sources).toEqual([]);
+  });
+
+  it('silently swallows Cosmos write errors and warns', async () => {
+    mockUpsert.mockRejectedValueOnce(new Error('cosmos timeout'));
+    const logger = { warn: jest.fn() };
+    await expect(captureConversation({ ...VALID_CAPTURE, logger })).resolves.not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to capture conversation'));
+  });
+
+  it('skips write and warns when required fields are missing', async () => {
+    const logger = { warn: jest.fn() };
+    await captureConversation({ ...VALID_CAPTURE, userId: undefined, logger });
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Missing required fields'));
+  });
+});

--- a/apps/fiona-slack/tests/agent/conversation-capture-store.test.js
+++ b/apps/fiona-slack/tests/agent/conversation-capture-store.test.js
@@ -68,16 +68,14 @@ describe('conversation-capture-store - Cosmos not configured', () => {
     delete process.env.CAPTURE_ALL_CONVERSATIONS;
   });
 
-  it('is a no-op and warns once when Cosmos is not configured', async () => {
+  it('warns exactly once per module lifetime when Cosmos is not configured', async () => {
     const logger = { warn: jest.fn() };
     await captureConversation({ ...VALID_CAPTURE, logger });
     expect(mockUpsert).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('CosmosDB not configured'));
-  });
 
-  it('warns only once across multiple calls', async () => {
-    const logger = { warn: jest.fn() };
-    await captureConversation({ ...VALID_CAPTURE, logger });
+    // Second call — same or different logger — flag is already set, no additional warning
     await captureConversation({ ...VALID_CAPTURE, logger });
     expect(logger.warn).toHaveBeenCalledTimes(1);
   });

--- a/apps/fiona-slack/tests/agent/feedback-store-cosmos.test.js
+++ b/apps/fiona-slack/tests/agent/feedback-store-cosmos.test.js
@@ -104,9 +104,11 @@ describe('recordFeedback - with connection string', () => {
     });
 
     const [doc, options] = mockUpsert.mock.calls[0];
-    expect(options).toEqual({
-      partitionKey: [doc.deploymentType, doc.feedbackId],
-    });
+    expect(options).toEqual(
+      expect.objectContaining({
+        partitionKey: [doc.deploymentType, doc.feedbackId],
+      }),
+    );
   });
 
   it('resolves without error on success', async () => {
@@ -179,5 +181,24 @@ describe('recordFeedback - with connection string', () => {
 
     const [doc] = mockUpsert.mock.calls[0];
     expect(doc.reason).toBeNull();
+  });
+
+  it('logs a warning and does not throw when upsert fails', async () => {
+    mockUpsert.mockRejectedValueOnce(new Error('Cosmos write failure'));
+    const logger = { warn: jest.fn() };
+
+    await expect(
+      recordFeedback({
+        userId: 'U999',
+        channelId: 'C999',
+        messageTs: '1234567890.000006',
+        value: 'good-feedback',
+        userMessage: null,
+        botResponse: null,
+        logger,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to record feedback'));
   });
 });

--- a/apps/fiona-slack/tests/agent/interaction-store-cosmos.test.js
+++ b/apps/fiona-slack/tests/agent/interaction-store-cosmos.test.js
@@ -127,9 +127,11 @@ describe('recordInteraction - with connection string', () => {
     });
 
     const [doc, options] = mockUpsert.mock.calls[0];
-    expect(options).toEqual({
-      partitionKey: [doc.deploymentType, doc.userId],
-    });
+    expect(options).toEqual(
+      expect.objectContaining({
+        partitionKey: [doc.deploymentType, doc.userId],
+      }),
+    );
   });
 
   it('resolves without error on success', async () => {

--- a/apps/fiona-slack/tests/agent/interaction-store.test.js
+++ b/apps/fiona-slack/tests/agent/interaction-store.test.js
@@ -120,7 +120,7 @@ describe('interaction-store - with connection string', () => {
     expect(doc.rateLimited).toBe(false);
     expect(doc.interactionType).toBe('app_mention');
     expect(doc.timestamp).toBeDefined();
-    expect(options).toEqual({ partitionKey: [doc.deploymentType, doc.userId] });
+    expect(options).toEqual(expect.objectContaining({ partitionKey: [doc.deploymentType, doc.userId] }));
   });
 
   it('sets errorType on the document when status is error', async () => {

--- a/apps/fiona-slack/tests/agent/llm-caller.aggregate-perplexity.test.js
+++ b/apps/fiona-slack/tests/agent/llm-caller.aggregate-perplexity.test.js
@@ -246,5 +246,6 @@ describe('callLLM returns botText alongside metadata', () => {
 
     expect(result).toHaveProperty('metadata');
     expect(result).toHaveProperty('botText', 'Hello world');
+    expect(result).toHaveProperty('systemPromptVersion', 'v1');
   });
 });

--- a/apps/fiona-slack/tests/agent/llm-caller.aggregate-perplexity.test.js
+++ b/apps/fiona-slack/tests/agent/llm-caller.aggregate-perplexity.test.js
@@ -149,7 +149,7 @@ describe('callPerplexityChat – buffer and linkify', () => {
       makeStream([{ text: 'Result [1].', citations: ['https://result.example.com'] }]),
     );
 
-    const citations = await callPerplexityChat(streamer, [{ role: 'user', content: 'hello' }]);
+    const { citations } = await callPerplexityChat(streamer, [{ role: 'user', content: 'hello' }]);
 
     expect(citations).toEqual(['https://result.example.com']);
   });
@@ -230,5 +230,21 @@ describe('callLLM error path does not mask original failure', () => {
 
     await expect(callLLM(intercepting, [{ role: 'user', content: 'hi' }], makeLogger())).rejects.toBe(llmError);
     expect(captured.envelope.finalize_state).toBe('ready_to_finalize');
+  });
+});
+
+describe('callLLM returns botText alongside metadata', () => {
+  it('returns botText alongside the metadata envelope', async () => {
+    const fakeStreamer = { append: jest.fn().mockResolvedValue(undefined), stop: jest.fn() };
+    mockCreate.mockResolvedValueOnce(
+      (async function* () {
+        yield { choices: [{ delta: { content: 'Hello world' } }] };
+      })(),
+    );
+
+    const result = await callLLM(fakeStreamer, [{ role: 'user', content: 'hi' }], { error: jest.fn(), warn: jest.fn(), info: jest.fn() });
+
+    expect(result).toHaveProperty('metadata');
+    expect(result).toHaveProperty('botText', 'Hello world');
   });
 });

--- a/apps/fiona-slack/tests/agent/llm-caller.metadata.test.js
+++ b/apps/fiona-slack/tests/agent/llm-caller.metadata.test.js
@@ -196,4 +196,3 @@ describe('handleMetadataTimeout', () => {
     expect(() => handleMetadataTimeout(null)).not.toThrow();
   });
 });
-

--- a/apps/fiona-slack/tests/agent/llm-caller.metadata.test.js
+++ b/apps/fiona-slack/tests/agent/llm-caller.metadata.test.js
@@ -196,3 +196,4 @@ describe('handleMetadataTimeout', () => {
     expect(() => handleMetadataTimeout(null)).not.toThrow();
   });
 });
+

--- a/apps/fiona-slack/tests/agent/thread-history.test.js
+++ b/apps/fiona-slack/tests/agent/thread-history.test.js
@@ -244,6 +244,34 @@ describe('buildThreadHistory', () => {
       const result = await buildThreadHistory(mockClient, 'C123', '123.456', { maxChars: 10 });
       expect(result).toHaveLength(1);
     });
+
+    it('falls back to currentText when truncation leaves only a lone assistant message', async () => {
+      // Truncation preserves at least one message (the assistant reply), then
+      // dropLeadingAssistantMessages removes it, leaving an empty array that
+      // triggers the currentText fallback.
+      mockClient.conversations.replies.mockResolvedValueOnce({
+        messages: [
+          { text: 'Hi', bot_id: undefined },
+          { text: 'A'.repeat(100), bot_id: 'B123', subtype: 'bot_message' },
+        ],
+      });
+      const result = await buildThreadHistory(mockClient, 'C123', '123.456', {
+        maxChars: 10,
+        currentText: 'New question',
+      });
+      expect(result).toEqual([{ role: 'user', content: 'New question' }]);
+    });
+
+    it('returns empty array when truncation leaves only a lone assistant message and no currentText', async () => {
+      mockClient.conversations.replies.mockResolvedValueOnce({
+        messages: [
+          { text: 'Hi', bot_id: undefined },
+          { text: 'A'.repeat(100), bot_id: 'B123', subtype: 'bot_message' },
+        ],
+      });
+      const result = await buildThreadHistory(mockClient, 'C123', '123.456', { maxChars: 10 });
+      expect(result).toEqual([]);
+    });
   });
 
   describe('error handling', () => {

--- a/apps/fiona-slack/tests/listeners/assistant/message.test.js
+++ b/apps/fiona-slack/tests/listeners/assistant/message.test.js
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../../../src/agent/llm-caller.js', () => ({
   callLLM: jest.fn().mockResolvedValue({ metadata: null, botText: '' }),
   finalizeMetadataEnvelope: jest.fn(),
   handleMetadataTimeout: jest.fn(),
+  LLM_MODEL: 'sonar-pro',
   CITATION_POLICY: {
     citation_rendering_enabled: true,
     FEATURE_FLAG_EVIDENCE_ROW: false,
@@ -27,6 +28,10 @@ jest.unstable_mockModule('../../../src/agent/llm-caller.js', () => ({
     FINALIZED: 'finalized',
     DEGRADED_NO_METADATA: 'degraded_no_metadata',
   },
+}));
+
+jest.unstable_mockModule('../../../src/agent/conversation-capture-store.js', () => ({
+  captureConversation: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.unstable_mockModule('../../../src/agent/rate-limiter.js', () => ({
@@ -54,6 +59,7 @@ const { checkRateLimit } = await import('../../../src/agent/rate-limiter.js');
 const { buildThreadHistory } = await import('../../../src/agent/thread-history.js');
 const { shouldFinalize, rollbackFinalization } = await import('../../../src/agent/utils/idempotent-finalize.js');
 const { recordInteraction } = await import('../../../src/agent/interaction-store.js');
+const { captureConversation } = await import('../../../src/agent/conversation-capture-store.js');
 
 describe('message (assistant thread handler)', () => {
   let mockSay;
@@ -458,5 +464,49 @@ describe('message (assistant thread handler)', () => {
     });
 
     expect(rollbackFinalization).not.toHaveBeenCalled();
+  });
+
+  describe('conversation capture', () => {
+    beforeEach(() => {
+      captureConversation.mockClear();
+      callLLM.mockResolvedValue({
+        metadata: { finalize_state: 'ready_to_finalize', sources: [{ url: 'https://a.com' }], source_index_map: {}, provider: 'perplexity' },
+        botText: 'Bot answer here.',
+      });
+    });
+
+    it('calls captureConversation with correct fields after a successful LLM response', async () => {
+      await messageHandler({
+        client: mockClient,
+        context: mockContext,
+        logger: mockLogger,
+        message: mockMessage,
+        say: mockSay,
+        setStatus: mockSetStatus,
+      });
+
+      expect(captureConversation).toHaveBeenCalledTimes(1);
+      const call = captureConversation.mock.calls[0][0];
+      expect(call.userId).toBe(mockContext.userId);
+      expect(call.channelId).toBe(mockMessage.channel);
+      expect(call.entryPoint).toBe('assistant_message');
+      expect(call.botResponse).toBe('Bot answer here.');
+      expect(call.llmProvider).toBe('perplexity');
+    });
+
+    it('does not call captureConversation when callLLM throws', async () => {
+      callLLM.mockRejectedValueOnce(new Error('LLM failure'));
+
+      await messageHandler({
+        client: mockClient,
+        context: mockContext,
+        logger: mockLogger,
+        message: mockMessage,
+        say: mockSay,
+        setStatus: mockSetStatus,
+      });
+
+      expect(captureConversation).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/fiona-slack/tests/listeners/assistant/message.test.js
+++ b/apps/fiona-slack/tests/listeners/assistant/message.test.js
@@ -492,10 +492,27 @@ describe('message (assistant thread handler)', () => {
       expect(call.entryPoint).toBe('assistant_message');
       expect(call.botResponse).toBe('Bot answer here.');
       expect(call.llmProvider).toBe('perplexity');
+      expect(call.teamId).toBeDefined();
+      expect(call.llmModel).toBeDefined();
     });
 
     it('does not call captureConversation when callLLM throws', async () => {
       callLLM.mockRejectedValueOnce(new Error('LLM failure'));
+
+      await messageHandler({
+        client: mockClient,
+        context: mockContext,
+        logger: mockLogger,
+        message: mockMessage,
+        say: mockSay,
+        setStatus: mockSetStatus,
+      });
+
+      expect(captureConversation).not.toHaveBeenCalled();
+    });
+
+    it('does not call captureConversation when shouldFinalize returns false', async () => {
+      shouldFinalize.mockReturnValueOnce(false);
 
       await messageHandler({
         client: mockClient,

--- a/apps/fiona-slack/tests/listeners/assistant/message.test.js
+++ b/apps/fiona-slack/tests/listeners/assistant/message.test.js
@@ -11,10 +11,11 @@ jest.unstable_mockModule('../../../src/agent/interaction-store.js', () => ({
 }));
 
 jest.unstable_mockModule('../../../src/agent/llm-caller.js', () => ({
-  callLLM: jest.fn().mockResolvedValue({ metadata: null, botText: '' }),
+  callLLM: jest.fn().mockResolvedValue({ metadata: null, botText: '', systemPromptVersion: 'v1' }),
   finalizeMetadataEnvelope: jest.fn(),
   handleMetadataTimeout: jest.fn(),
   LLM_MODEL: 'sonar-pro',
+  SYSTEM_PROMPT_VERSION: 'v1',
   CITATION_POLICY: {
     citation_rendering_enabled: true,
     FEATURE_FLAG_EVIDENCE_ROW: false,
@@ -386,6 +387,7 @@ describe('message (assistant thread handler)', () => {
         source_index_map: { 'https://a.com': 1 },
       },
       botText: 'test response',
+      systemPromptVersion: 'v1',
     });
 
     await messageHandler({
@@ -407,7 +409,7 @@ describe('message (assistant thread handler)', () => {
       sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs' }],
       source_index_map: { 'https://docs.ed-fi.org': 1 },
     };
-    callLLM.mockResolvedValueOnce({ metadata, botText: 'test response' });
+    callLLM.mockResolvedValueOnce({ metadata, botText: 'test response', systemPromptVersion: 'v1' });
 
     await messageHandler({
       client: mockClient,
@@ -472,6 +474,7 @@ describe('message (assistant thread handler)', () => {
       callLLM.mockResolvedValue({
         metadata: { finalize_state: 'ready_to_finalize', sources: [{ url: 'https://a.com' }], source_index_map: {}, provider: 'perplexity' },
         botText: 'Bot answer here.',
+        systemPromptVersion: 'v1',
       });
     });
 
@@ -494,6 +497,7 @@ describe('message (assistant thread handler)', () => {
       expect(call.llmProvider).toBe('perplexity');
       expect(call.teamId).toBeDefined();
       expect(call.llmModel).toBeDefined();
+      expect(call.systemPromptVersion).toBe('v1');
     });
 
     it('does not call captureConversation when callLLM throws', async () => {

--- a/apps/fiona-slack/tests/listeners/assistant/message.test.js
+++ b/apps/fiona-slack/tests/listeners/assistant/message.test.js
@@ -11,7 +11,7 @@ jest.unstable_mockModule('../../../src/agent/interaction-store.js', () => ({
 }));
 
 jest.unstable_mockModule('../../../src/agent/llm-caller.js', () => ({
-  callLLM: jest.fn().mockResolvedValue(undefined),
+  callLLM: jest.fn().mockResolvedValue({ metadata: null, botText: '' }),
   finalizeMetadataEnvelope: jest.fn(),
   handleMetadataTimeout: jest.fn(),
   CITATION_POLICY: {
@@ -374,9 +374,12 @@ describe('message (assistant thread handler)', () => {
 
   it('logs citation state and source count when metadata is present', async () => {
     callLLM.mockResolvedValueOnce({
-      finalize_state: 'ready_to_finalize',
-      sources: [{ url: 'https://a.com' }],
-      source_index_map: { 'https://a.com': 1 },
+      metadata: {
+        finalize_state: 'ready_to_finalize',
+        sources: [{ url: 'https://a.com' }],
+        source_index_map: { 'https://a.com': 1 },
+      },
+      botText: 'test response',
     });
 
     await messageHandler({
@@ -398,7 +401,7 @@ describe('message (assistant thread handler)', () => {
       sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs' }],
       source_index_map: { 'https://docs.ed-fi.org': 1 },
     };
-    callLLM.mockResolvedValueOnce(metadata);
+    callLLM.mockResolvedValueOnce({ metadata, botText: 'test response' });
 
     await messageHandler({
       client: mockClient,

--- a/apps/fiona-slack/tests/listeners/events/app-mention.test.js
+++ b/apps/fiona-slack/tests/listeners/events/app-mention.test.js
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../../../src/agent/llm-caller.js', () => ({
   callLLM: jest.fn().mockResolvedValue({ metadata: null, botText: '' }),
   finalizeMetadataEnvelope: jest.fn(),
   handleMetadataTimeout: jest.fn(),
+  LLM_MODEL: 'sonar-pro',
   CITATION_POLICY: {
     citation_rendering_enabled: true,
     FEATURE_FLAG_EVIDENCE_ROW: false,
@@ -48,12 +49,17 @@ jest.unstable_mockModule('../../../src/agent/utils/idempotent-finalize.js', () =
   rollbackFinalization: jest.fn(),
 }));
 
+jest.unstable_mockModule('../../../src/agent/conversation-capture-store.js', () => ({
+  captureConversation: jest.fn().mockResolvedValue(undefined),
+}));
+
 const { appMentionCallback } = await import('../../../src/listeners/events/app_mention.js');
 const { callLLM, finalizeMetadataEnvelope } = await import('../../../src/agent/llm-caller.js');
 const { checkRateLimit } = await import('../../../src/agent/rate-limiter.js');
 const { buildThreadHistory } = await import('../../../src/agent/thread-history.js');
 const { shouldFinalize, rollbackFinalization } = await import('../../../src/agent/utils/idempotent-finalize.js');
 const { recordInteraction } = await import('../../../src/agent/interaction-store.js');
+const { captureConversation } = await import('../../../src/agent/conversation-capture-store.js');
 
 describe('appMentionCallback', () => {
   let mockSay;
@@ -288,5 +294,35 @@ describe('appMentionCallback', () => {
     await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
 
     expect(rollbackFinalization).not.toHaveBeenCalled();
+  });
+
+  describe('conversation capture', () => {
+    beforeEach(() => {
+      captureConversation.mockClear();
+      callLLM.mockResolvedValue({
+        metadata: { finalize_state: 'ready_to_finalize', sources: [{ url: 'https://a.com' }], source_index_map: {}, provider: 'perplexity' },
+        botText: 'Bot answer here.',
+      });
+    });
+
+    it('calls captureConversation with correct fields after a successful LLM response', async () => {
+      await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
+
+      expect(captureConversation).toHaveBeenCalledTimes(1);
+      const call = captureConversation.mock.calls[0][0];
+      expect(call.userId).toBe(mockEvent.user);
+      expect(call.channelId).toBe(mockEvent.channel);
+      expect(call.entryPoint).toBe('app_mention');
+      expect(call.botResponse).toBe('Bot answer here.');
+      expect(call.llmProvider).toBe('perplexity');
+    });
+
+    it('does not call captureConversation when callLLM throws', async () => {
+      callLLM.mockRejectedValueOnce(new Error('LLM failure'));
+
+      await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
+
+      expect(captureConversation).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/fiona-slack/tests/listeners/events/app-mention.test.js
+++ b/apps/fiona-slack/tests/listeners/events/app-mention.test.js
@@ -11,7 +11,7 @@ jest.unstable_mockModule('../../../src/agent/interaction-store.js', () => ({
 }));
 
 jest.unstable_mockModule('../../../src/agent/llm-caller.js', () => ({
-  callLLM: jest.fn().mockResolvedValue(undefined),
+  callLLM: jest.fn().mockResolvedValue({ metadata: null, botText: '' }),
   finalizeMetadataEnvelope: jest.fn(),
   handleMetadataTimeout: jest.fn(),
   CITATION_POLICY: {
@@ -239,9 +239,12 @@ describe('appMentionCallback', () => {
 
   it('logs citation state and source count when metadata is present', async () => {
     callLLM.mockResolvedValueOnce({
-      finalize_state: 'ready_to_finalize',
-      sources: [{ url: 'https://a.com' }],
-      source_index_map: { 'https://a.com': 1 },
+      metadata: {
+        finalize_state: 'ready_to_finalize',
+        sources: [{ url: 'https://a.com' }],
+        source_index_map: { 'https://a.com': 1 },
+      },
+      botText: 'test response',
     });
 
     await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
@@ -256,7 +259,7 @@ describe('appMentionCallback', () => {
       sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs' }],
       source_index_map: { 'https://docs.ed-fi.org': 1 },
     };
-    callLLM.mockResolvedValueOnce(metadata);
+    callLLM.mockResolvedValueOnce({ metadata, botText: 'test response' });
 
     await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
 

--- a/apps/fiona-slack/tests/listeners/events/app-mention.test.js
+++ b/apps/fiona-slack/tests/listeners/events/app-mention.test.js
@@ -11,10 +11,11 @@ jest.unstable_mockModule('../../../src/agent/interaction-store.js', () => ({
 }));
 
 jest.unstable_mockModule('../../../src/agent/llm-caller.js', () => ({
-  callLLM: jest.fn().mockResolvedValue({ metadata: null, botText: '' }),
+  callLLM: jest.fn().mockResolvedValue({ metadata: null, botText: '', systemPromptVersion: 'v1' }),
   finalizeMetadataEnvelope: jest.fn(),
   handleMetadataTimeout: jest.fn(),
   LLM_MODEL: 'sonar-pro',
+  SYSTEM_PROMPT_VERSION: 'v1',
   CITATION_POLICY: {
     citation_rendering_enabled: true,
     FEATURE_FLAG_EVIDENCE_ROW: false,
@@ -251,6 +252,7 @@ describe('appMentionCallback', () => {
         source_index_map: { 'https://a.com': 1 },
       },
       botText: 'test response',
+      systemPromptVersion: 'v1',
     });
 
     await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
@@ -265,7 +267,7 @@ describe('appMentionCallback', () => {
       sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs' }],
       source_index_map: { 'https://docs.ed-fi.org': 1 },
     };
-    callLLM.mockResolvedValueOnce({ metadata, botText: 'test response' });
+    callLLM.mockResolvedValueOnce({ metadata, botText: 'test response', systemPromptVersion: 'v1' });
 
     await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
 
@@ -302,6 +304,7 @@ describe('appMentionCallback', () => {
       callLLM.mockResolvedValue({
         metadata: { finalize_state: 'ready_to_finalize', sources: [{ url: 'https://a.com' }], source_index_map: {}, provider: 'perplexity' },
         botText: 'Bot answer here.',
+        systemPromptVersion: 'v1',
       });
     });
 
@@ -317,6 +320,7 @@ describe('appMentionCallback', () => {
       expect(call.llmProvider).toBe('perplexity');
       expect(call.teamId).toBeDefined();
       expect(call.llmModel).toBeDefined();
+      expect(call.systemPromptVersion).toBe('v1');
     });
 
     it('does not call captureConversation when callLLM throws', async () => {

--- a/apps/fiona-slack/tests/listeners/events/app-mention.test.js
+++ b/apps/fiona-slack/tests/listeners/events/app-mention.test.js
@@ -315,10 +315,20 @@ describe('appMentionCallback', () => {
       expect(call.entryPoint).toBe('app_mention');
       expect(call.botResponse).toBe('Bot answer here.');
       expect(call.llmProvider).toBe('perplexity');
+      expect(call.teamId).toBeDefined();
+      expect(call.llmModel).toBeDefined();
     });
 
     it('does not call captureConversation when callLLM throws', async () => {
       callLLM.mockRejectedValueOnce(new Error('LLM failure'));
+
+      await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
+
+      expect(captureConversation).not.toHaveBeenCalled();
+    });
+
+    it('does not call captureConversation when shouldFinalize returns false', async () => {
+      shouldFinalize.mockReturnValueOnce(false);
 
       await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
 

--- a/apps/usage-report-function/README.md
+++ b/apps/usage-report-function/README.md
@@ -62,9 +62,9 @@ When `SLACK_DRY_RUN=true`, the function skips Key Vault and the Slack post entir
 
 If using the local emulator, run this once to create the database and containers:
 
-```bash
+```pwsh
 cd ../fiona-slack
-NODE_TLS_REJECT_UNAUTHORIZED=0 npm run setup:emulator
+$env:NODE_TLS_REJECT_UNAUTHORIZED=0; npm run setup:emulator
 ```
 
 ### Run the function

--- a/apps/usage-report-function/package.json
+++ b/apps/usage-report-function/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "WeeklyReportTrigger/index.js",
   "scripts": {
-    "start": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 func start",
+    "start": "func start",
     "lint": "npx @biomejs/biome check lib/ test/ WeeklyReportTrigger/",
     "lint:fix": "npx @biomejs/biome check --write lib/ test/ WeeklyReportTrigger/",
     "test": "node --experimental-vm-modules node_modules/jest-cli/bin/jest.js",

--- a/docs/superpowers/plans/2026-06-03-conversation-capture.md
+++ b/docs/superpowers/plans/2026-06-03-conversation-capture.md
@@ -4,6 +4,8 @@
 
 **Goal:** Capture all Fiona conversations (user message + bot response + thread history + metadata) to a new Cosmos DB `conversations` container for human evaluation, gated by a `CAPTURE_ALL_CONVERSATIONS` env var.
 
+> **Implementation update (2026-06-08):** The merged implementation uses a **180-day TTL** (not 360) and includes `systemPromptVersion` in captured conversation records. Follow-up hardening/refactor work is tracked separately in issue #57.
+
 **Architecture:** A new `conversation-capture-store.js` module (following the existing `interaction-store.js` / `feedback-store.js` pattern) writes to a dedicated Cosmos container. `callLLM` is modified to return the accumulated bot response text alongside the metadata envelope, so listeners can pass both to the store after a successful LLM call. Infrastructure provisioning adds the container via Bicep. All changes are independent of the slash command work (AI-119) and will compose cleanly after that PR merges.
 
 **Tech Stack:** Node.js (ESM), `@azure/cosmos`, `@azure/identity`, Jest (`jest.unstable_mockModule`), Azure Bicep

--- a/docs/superpowers/plans/2026-06-03-conversation-capture.md
+++ b/docs/superpowers/plans/2026-06-03-conversation-capture.md
@@ -1,0 +1,981 @@
+# AI-129 Conversation Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture all Fiona conversations (user message + bot response + thread history + metadata) to a new Cosmos DB `conversations` container for human evaluation, gated by a `CAPTURE_ALL_CONVERSATIONS` env var.
+
+**Architecture:** A new `conversation-capture-store.js` module (following the existing `interaction-store.js` / `feedback-store.js` pattern) writes to a dedicated Cosmos container. `callLLM` is modified to return the accumulated bot response text alongside the metadata envelope, so listeners can pass both to the store after a successful LLM call. Infrastructure provisioning adds the container via Bicep. All changes are independent of the slash command work (AI-119) and will compose cleanly after that PR merges.
+
+**Tech Stack:** Node.js (ESM), `@azure/cosmos`, `@azure/identity`, Jest (`jest.unstable_mockModule`), Azure Bicep
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Modify | `apps/fiona-slack/src/agent/llm-caller.js` | Return `{ metadata, botText }` from `callLLM`; return `{ botText, citations }` from `callPerplexityChat`; export `LLM_MODEL` |
+| Modify | `apps/fiona-slack/tests/agent/llm-caller.aggregate-perplexity.test.js` | Update destructure for new `callPerplexityChat` return shape |
+| Create | `apps/fiona-slack/src/agent/conversation-capture-store.js` | Cosmos writer for full conversation records; no-ops when flag is off or Cosmos unconfigured |
+| Create | `apps/fiona-slack/tests/agent/conversation-capture-store.test.js` | Unit tests for the store module |
+| Modify | `apps/fiona-slack/src/listeners/events/app_mention.js` | Destructure `{ metadata, botText }` from `callLLM`; call `captureConversation` after success |
+| Modify | `apps/fiona-slack/src/listeners/assistant/message.js` | Same as above for the assistant message path |
+| Modify | `apps/fiona-slack/tests/listeners/events/app-mention.test.js` | Update mocks for new `callLLM` shape; assert capture is called |
+| Modify | `apps/fiona-slack/tests/listeners/assistant/message.test.js` | Same |
+| Modify | `infra/fiona-slack-container/main.bicep` | Add `conversations` container (360-day TTL); add `COSMOS_CONVERSATIONS_CONTAINER` and `CAPTURE_ALL_CONVERSATIONS` env vars |
+
+---
+
+## Task 1: Expose bot text from `callLLM` and export `LLM_MODEL`
+
+`callPerplexityChat` already accumulates the full LLM response in `linkifiedText` but currently discards it (returning only `citations`). This task surfaces that text through `callLLM` so listeners can capture it.
+
+**Files:**
+- Modify: `apps/fiona-slack/src/agent/llm-caller.js`
+- Modify: `apps/fiona-slack/tests/agent/llm-caller.aggregate-perplexity.test.js`
+
+- [ ] **Step 1: Write the failing test for `callLLM` returning `botText`**
+
+Add this test inside the existing `describe` block in `apps/fiona-slack/tests/agent/llm-caller.metadata.test.js` (append before the final closing `}`):
+
+```javascript
+it('returns botText alongside the metadata envelope', async () => {
+  process.env.PERPLEXITY_API_KEY = 'test-key';
+  const { callLLM } = await import('../../src/agent/llm-caller.js');
+
+  const fakeStreamer = { append: jest.fn().mockResolvedValue(undefined), stop: jest.fn() };
+  // mockCreate is already set up in this test file's beforeAll; provide a minimal stream
+  mockCreate.mockResolvedValueOnce(
+    (async function* () {
+      yield { choices: [{ delta: { content: 'Hello world' } }] };
+    })(),
+  );
+
+  const result = await callLLM(fakeStreamer, [{ role: 'user', content: 'hi' }], { error: jest.fn(), warn: jest.fn(), info: jest.fn() });
+
+  expect(result).toHaveProperty('metadata');
+  expect(result).toHaveProperty('botText', 'Hello world');
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd apps/fiona-slack && node --experimental-vm-modules node_modules/.bin/jest tests/agent/llm-caller.metadata.test.js --no-coverage 2>&1 | tail -20
+```
+
+Expected: FAIL — `result.botText` is undefined (current `callLLM` returns the metadata envelope directly, not `{ metadata, botText }`).
+
+- [ ] **Step 3: Modify `callPerplexityChat` to return `{ botText, citations }`**
+
+In `apps/fiona-slack/src/agent/llm-caller.js`, find the end of `callPerplexityChat` (around line 415):
+
+```javascript
+  if (textBuffer) {
+    const sourceIndexMap = streamer?.__citation_metadata?.source_index_map || {};
+    const linkifiedText = linkifyCitationMarkers(textBuffer, sourceIndexMap);
+    await streamer.append({ markdown_text: linkifiedText });
+  }
+
+  return citations;
+}
+```
+
+Replace with:
+
+```javascript
+  let botText = '';
+  if (textBuffer) {
+    const sourceIndexMap = streamer?.__citation_metadata?.source_index_map || {};
+    botText = linkifyCitationMarkers(textBuffer, sourceIndexMap);
+    await streamer.append({ markdown_text: botText });
+  }
+
+  return { botText, citations };
+}
+```
+
+- [ ] **Step 4: Modify `callLLM` to capture `botText` and return `{ metadata, botText }`**
+
+In `apps/fiona-slack/src/agent/llm-caller.js`, find inside `callLLM` (around line 450):
+
+```javascript
+  try {
+    await callPerplexityChat(streamer, [{ role: 'system', content: SYSTEM_PROMPT }, ...prompts]);
+```
+
+Replace with:
+
+```javascript
+  let botText = '';
+  try {
+    ({ botText } = await callPerplexityChat(streamer, [{ role: 'system', content: SYSTEM_PROMPT }, ...prompts]));
+```
+
+Then find the `return metadata;` line at the end of `callLLM` and replace it:
+
+```javascript
+  return { metadata, botText };
+```
+
+- [ ] **Step 5: Export `LLM_MODEL` from `llm-caller.js`**
+
+Find the line (near the top of the file):
+
+```javascript
+const PERPLEXITY_API_MODEL = process.env.PERPLEXITY_API_MODEL || 'sonar';
+```
+
+Add after it:
+
+```javascript
+export const LLM_MODEL = PERPLEXITY_API_MODEL;
+```
+
+- [ ] **Step 6: Fix the `callPerplexityChat` test that checks the `citations` return**
+
+In `apps/fiona-slack/tests/agent/llm-caller.aggregate-perplexity.test.js`, find (around line 152):
+
+```javascript
+    const citations = await callPerplexityChat(streamer, [{ role: 'user', content: 'hello' }]);
+
+    expect(citations).toEqual(['https://result.example.com']);
+```
+
+Replace with:
+
+```javascript
+    const { citations } = await callPerplexityChat(streamer, [{ role: 'user', content: 'hello' }]);
+
+    expect(citations).toEqual(['https://result.example.com']);
+```
+
+- [ ] **Step 7: Run all llm-caller tests to verify they pass**
+
+```bash
+cd apps/fiona-slack && node --experimental-vm-modules node_modules/.bin/jest tests/agent/llm-caller --no-coverage 2>&1 | tail -30
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 8: Update listener callers to destructure the new return shape**
+
+In `apps/fiona-slack/src/listeners/events/app_mention.js`, find:
+
+```javascript
+      const metadata = await callLLM(streamer, prompts, logger);
+```
+
+Replace with:
+
+```javascript
+      const { metadata, botText } = await callLLM(streamer, prompts, logger);
+```
+
+In `apps/fiona-slack/src/listeners/assistant/message.js`, find (inside the `else` block):
+
+```javascript
+        const metadata = await callLLM(streamer, prompts, logger);
+```
+
+Replace with:
+
+```javascript
+        const { metadata, botText } = await callLLM(streamer, prompts, logger);
+```
+
+> `botText` is now declared in scope for use in Task 3 (capture wiring). The `metadata` variable is otherwise used identically.
+
+- [ ] **Step 9: Update the `callLLM` mock default in listener tests**
+
+In `apps/fiona-slack/tests/listeners/events/app-mention.test.js`, find the mock module factory:
+
+```javascript
+  callLLM: jest.fn().mockResolvedValue(undefined),
+```
+
+Replace with:
+
+```javascript
+  callLLM: jest.fn().mockResolvedValue({ metadata: null, botText: '' }),
+```
+
+In `apps/fiona-slack/tests/listeners/assistant/message.test.js`, make the same change:
+
+```javascript
+  callLLM: jest.fn().mockResolvedValue({ metadata: null, botText: '' }),
+```
+
+- [ ] **Step 10: Update `mockResolvedValueOnce` calls in listener tests to wrap metadata in new shape**
+
+In `apps/fiona-slack/tests/listeners/events/app-mention.test.js`:
+
+Find the citation-logging test:
+```javascript
+    callLLM.mockResolvedValueOnce({
+      finalize_state: 'ready_to_finalize',
+      sources: [{ url: 'https://a.com' }],
+      source_index_map: { 'https://a.com': 1 },
+    });
+```
+Replace with:
+```javascript
+    callLLM.mockResolvedValueOnce({
+      metadata: {
+        finalize_state: 'ready_to_finalize',
+        sources: [{ url: 'https://a.com' }],
+        source_index_map: { 'https://a.com': 1 },
+      },
+      botText: 'test response',
+    });
+```
+
+Find the `finalizeMetadataEnvelope` test:
+```javascript
+    const metadata = {
+      finalize_state: 'ready_to_finalize',
+      sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs' }],
+      source_index_map: { 'https://docs.ed-fi.org': 1 },
+    };
+    callLLM.mockResolvedValueOnce(metadata);
+```
+Replace with:
+```javascript
+    const metadata = {
+      finalize_state: 'ready_to_finalize',
+      sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs' }],
+      source_index_map: { 'https://docs.ed-fi.org': 1 },
+    };
+    callLLM.mockResolvedValueOnce({ metadata, botText: 'test response' });
+```
+
+Apply the same two changes in `apps/fiona-slack/tests/listeners/assistant/message.test.js`.
+
+- [ ] **Step 11: Run all listener tests to verify they pass**
+
+```bash
+cd apps/fiona-slack && node --experimental-vm-modules node_modules/.bin/jest tests/listeners --no-coverage 2>&1 | tail -30
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 12: Run the full test suite**
+
+```bash
+cd apps/fiona-slack && node --experimental-vm-modules node_modules/.bin/jest --no-coverage 2>&1 | tail -20
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add apps/fiona-slack/src/agent/llm-caller.js \
+        apps/fiona-slack/tests/agent/llm-caller.metadata.test.js \
+        apps/fiona-slack/tests/agent/llm-caller.aggregate-perplexity.test.js \
+        apps/fiona-slack/src/listeners/events/app_mention.js \
+        apps/fiona-slack/src/listeners/assistant/message.js \
+        apps/fiona-slack/tests/listeners/events/app-mention.test.js \
+        apps/fiona-slack/tests/listeners/assistant/message.test.js
+git commit -m "refactor(ai-129): expose botText from callLLM for conversation capture"
+```
+
+---
+
+## Task 2: Implement `conversation-capture-store.js`
+
+**Files:**
+- Create: `apps/fiona-slack/src/agent/conversation-capture-store.js`
+- Create: `apps/fiona-slack/tests/agent/conversation-capture-store.test.js`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `apps/fiona-slack/tests/agent/conversation-capture-store.test.js`:
+
+```javascript
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { describe, it, expect, jest, beforeAll, afterAll, beforeEach } from '@jest/globals';
+
+const mockUpsert = jest.fn().mockResolvedValue({});
+const mockContainerObj = { items: { upsert: mockUpsert } };
+const mockDatabase = { container: jest.fn().mockReturnValue(mockContainerObj) };
+const MockCosmosClient = jest.fn().mockImplementation(() => ({
+  database: jest.fn().mockReturnValue(mockDatabase),
+}));
+
+jest.unstable_mockModule('@azure/cosmos', () => ({
+  CosmosClient: MockCosmosClient,
+}));
+
+jest.unstable_mockModule('@azure/identity', () => ({
+  DefaultAzureCredential: jest.fn(),
+}));
+
+const VALID_CAPTURE = {
+  userId: 'U123',
+  teamId: 'T456',
+  channelId: 'C789',
+  threadTs: '1000.0001',
+  messageTs: '1000.0002',
+  entryPoint: 'app_mention',
+  userMessage: 'What is Ed-Fi?',
+  botResponse: 'Ed-Fi is a data standard.',
+  threadHistory: [{ role: 'user', content: 'What is Ed-Fi?' }],
+  llmProvider: 'perplexity',
+  llmModel: 'sonar',
+  sources: [{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs', index: 1 }],
+};
+
+describe('conversation-capture-store - CAPTURE_ALL_CONVERSATIONS disabled', () => {
+  let captureConversation;
+
+  beforeAll(async () => {
+    delete process.env.CAPTURE_ALL_CONVERSATIONS;
+    delete process.env.COSMOS_ENDPOINT;
+    delete process.env.COSMOS_CONNECTION_STRING;
+    delete process.env.COSMOS_CONVERSATIONS_CONTAINER;
+    ({ captureConversation } = await import('../../src/agent/conversation-capture-store.js'));
+  });
+
+  it('is a no-op when CAPTURE_ALL_CONVERSATIONS is not set', async () => {
+    await captureConversation(VALID_CAPTURE);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('conversation-capture-store - Cosmos not configured', () => {
+  let captureConversation;
+
+  beforeAll(async () => {
+    process.env.CAPTURE_ALL_CONVERSATIONS = 'true';
+    delete process.env.COSMOS_ENDPOINT;
+    delete process.env.COSMOS_CONNECTION_STRING;
+    delete process.env.COSMOS_CONVERSATIONS_CONTAINER;
+    jest.resetModules();
+    ({ captureConversation } = await import('../../src/agent/conversation-capture-store.js'));
+  });
+
+  afterAll(() => {
+    delete process.env.CAPTURE_ALL_CONVERSATIONS;
+  });
+
+  it('is a no-op and warns once when Cosmos is not configured', async () => {
+    const logger = { warn: jest.fn() };
+    await captureConversation({ ...VALID_CAPTURE, logger });
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('CosmosDB not configured'));
+  });
+
+  it('warns only once across multiple calls', async () => {
+    const logger = { warn: jest.fn() };
+    await captureConversation({ ...VALID_CAPTURE, logger });
+    await captureConversation({ ...VALID_CAPTURE, logger });
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('conversation-capture-store - Cosmos configured via connection string', () => {
+  let captureConversation;
+
+  beforeAll(async () => {
+    process.env.CAPTURE_ALL_CONVERSATIONS = 'true';
+    process.env.COSMOS_CONNECTION_STRING = 'AccountEndpoint=https://test.documents.azure.com:443/;AccountKey=dGVzdA==';
+    process.env.COSMOS_CONVERSATIONS_CONTAINER = 'conversations';
+    process.env.DEPLOYMENT_TYPE = 'local';
+    jest.resetModules();
+    MockCosmosClient.mockClear();
+    mockUpsert.mockClear();
+    ({ captureConversation } = await import('../../src/agent/conversation-capture-store.js'));
+  });
+
+  afterAll(() => {
+    delete process.env.CAPTURE_ALL_CONVERSATIONS;
+    delete process.env.COSMOS_CONNECTION_STRING;
+    delete process.env.COSMOS_CONVERSATIONS_CONTAINER;
+  });
+
+  beforeEach(() => {
+    mockUpsert.mockClear();
+  });
+
+  it('upserts a document with all required fields', async () => {
+    await captureConversation(VALID_CAPTURE);
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const [doc] = mockUpsert.mock.calls[0];
+    expect(doc.id).toBe('U123_1000.0001_1000.0002');
+    expect(doc.userId).toBe('U123');
+    expect(doc.teamId).toBe('T456');
+    expect(doc.channelId).toBe('C789');
+    expect(doc.threadTs).toBe('1000.0001');
+    expect(doc.messageTs).toBe('1000.0002');
+    expect(doc.entryPoint).toBe('app_mention');
+    expect(doc.userMessage).toBe('What is Ed-Fi?');
+    expect(doc.botResponse).toBe('Ed-Fi is a data standard.');
+    expect(doc.threadHistory).toEqual([{ role: 'user', content: 'What is Ed-Fi?' }]);
+    expect(doc.llmProvider).toBe('perplexity');
+    expect(doc.llmModel).toBe('sonar');
+    expect(doc.sources).toEqual([{ url: 'https://docs.ed-fi.org', title: 'Ed-Fi Docs', index: 1 }]);
+    expect(doc.deploymentType).toBe('local');
+    expect(doc.ttl).toBe(31_104_000);
+    expect(doc.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('uses deploymentType and userId as the partition key', async () => {
+    await captureConversation(VALID_CAPTURE);
+    const [, options] = mockUpsert.mock.calls[0];
+    expect(options.partitionKey).toEqual(['local', 'U123']);
+  });
+
+  it('defaults sources to empty array when not provided', async () => {
+    await captureConversation({ ...VALID_CAPTURE, sources: undefined });
+    const [doc] = mockUpsert.mock.calls[0];
+    expect(doc.sources).toEqual([]);
+  });
+
+  it('silently swallows Cosmos write errors and warns', async () => {
+    mockUpsert.mockRejectedValueOnce(new Error('cosmos timeout'));
+    const logger = { warn: jest.fn() };
+    await expect(captureConversation({ ...VALID_CAPTURE, logger })).resolves.not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to capture conversation'));
+  });
+
+  it('skips write and warns when required fields are missing', async () => {
+    const logger = { warn: jest.fn() };
+    await captureConversation({ ...VALID_CAPTURE, userId: undefined, logger });
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Missing required fields'));
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd apps/fiona-slack && node --experimental-vm-modules node_modules/.bin/jest tests/agent/conversation-capture-store --no-coverage 2>&1 | tail -20
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `conversation-capture-store.js`**
+
+Create `apps/fiona-slack/src/agent/conversation-capture-store.js`:
+
+```javascript
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { CosmosClient } from '@azure/cosmos';
+import { DefaultAzureCredential } from '@azure/identity';
+
+const CAPTURE_ALL_CONVERSATIONS = process.env.CAPTURE_ALL_CONVERSATIONS === 'true';
+const COSMOS_ENDPOINT = process.env.COSMOS_ENDPOINT;
+const COSMOS_KEY = process.env.COSMOS_KEY;
+const COSMOS_CONNECTION_STRING = process.env.COSMOS_CONNECTION_STRING;
+const COSMOS_DATABASE = process.env.COSMOS_DATABASE || 'fiona';
+const COSMOS_CONVERSATIONS_CONTAINER = process.env.COSMOS_CONVERSATIONS_CONTAINER || 'conversations';
+const DEPLOYMENT_TYPE = process.env.DEPLOYMENT_TYPE || 'local';
+
+// 360 days in seconds for per-document TTL
+const CONVERSATION_TTL_SECONDS = 31_104_000;
+
+let warnedMissingConfig = false;
+
+/** @type {import('@azure/cosmos').Container | null} */
+let container = null;
+
+/**
+ * @param {{ warn?: (msg: string) => void } | null} [logger]
+ * @returns {Promise<import('@azure/cosmos').Container | null>}
+ */
+async function getContainer(logger) {
+  if (container) return container;
+
+  let client;
+  if (COSMOS_CONNECTION_STRING) {
+    client = new CosmosClient(COSMOS_CONNECTION_STRING);
+  } else if (COSMOS_ENDPOINT && COSMOS_KEY) {
+    client = new CosmosClient({ endpoint: COSMOS_ENDPOINT, key: COSMOS_KEY });
+  } else if (COSMOS_ENDPOINT) {
+    client = new CosmosClient({
+      endpoint: COSMOS_ENDPOINT,
+      aadCredentials: new DefaultAzureCredential(),
+    });
+  } else {
+    if (!warnedMissingConfig) {
+      warnedMissingConfig = true;
+      logger?.warn?.(
+        'CosmosDB not configured — conversations will not be captured. Set COSMOS_CONNECTION_STRING or COSMOS_ENDPOINT.',
+      );
+    }
+    return null;
+  }
+
+  container = client.database(COSMOS_DATABASE).container(COSMOS_CONVERSATIONS_CONTAINER);
+  return container;
+}
+
+/**
+ * Capture a full conversation to Cosmos DB for human evaluation.
+ * No-ops silently when CAPTURE_ALL_CONVERSATIONS is false or Cosmos is unconfigured.
+ *
+ * @param {Object} capture
+ * @param {string} capture.userId - Slack user ID
+ * @param {string} [capture.teamId] - Slack workspace ID
+ * @param {string} capture.channelId - Slack channel ID
+ * @param {string} capture.threadTs - Thread timestamp (session identifier)
+ * @param {string} capture.messageTs - Message timestamp (event identifier)
+ * @param {string} capture.entryPoint - 'app_mention' or 'assistant_message'
+ * @param {string} capture.userMessage - The user's message text
+ * @param {string} capture.botResponse - The full bot response text
+ * @param {Array<{role: string, content: string}>} capture.threadHistory - Full thread context sent to LLM
+ * @param {string} capture.llmProvider - LLM provider name (e.g. 'perplexity')
+ * @param {string} capture.llmModel - LLM model name (e.g. 'sonar')
+ * @param {Array} [capture.sources] - Citation sources from metadata
+ * @param {{ warn?: (msg: string) => void }} [capture.logger] - Optional logger
+ */
+export async function captureConversation({
+  userId,
+  teamId,
+  channelId,
+  threadTs,
+  messageTs,
+  entryPoint,
+  userMessage,
+  botResponse,
+  threadHistory,
+  llmProvider,
+  llmModel,
+  sources,
+  logger,
+}) {
+  if (!CAPTURE_ALL_CONVERSATIONS) return;
+
+  const c = await getContainer(logger);
+  if (!c) return;
+
+  if (!userId || !channelId || !threadTs || !messageTs || !entryPoint) {
+    logger?.warn?.(
+      `Missing required fields for capturing conversation: ${JSON.stringify({ userId, channelId, threadTs, messageTs, entryPoint })}`,
+    );
+    return;
+  }
+
+  const doc = {
+    id: `${userId}_${threadTs}_${messageTs}`,
+    userId,
+    teamId,
+    channelId,
+    threadTs,
+    messageTs,
+    entryPoint,
+    userMessage,
+    botResponse,
+    threadHistory,
+    llmProvider,
+    llmModel,
+    sources: sources ?? [],
+    deploymentType: DEPLOYMENT_TYPE,
+    timestamp: new Date().toISOString(),
+    ttl: CONVERSATION_TTL_SECONDS,
+  };
+
+  try {
+    await c.items.upsert(doc, {
+      partitionKey: [doc.deploymentType, doc.userId],
+    });
+  } catch (error) {
+    logger?.warn?.(`Failed to capture conversation to Cosmos DB: ${error.message}`);
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd apps/fiona-slack && node --experimental-vm-modules node_modules/.bin/jest tests/agent/conversation-capture-store --no-coverage 2>&1 | tail -20
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/fiona-slack/src/agent/conversation-capture-store.js \
+        apps/fiona-slack/tests/agent/conversation-capture-store.test.js
+git commit -m "feat(ai-129): add conversation-capture-store for full conversation persistence"
+```
+
+---
+
+## Task 3: Wire capture into `app_mention.js` and `message.js`
+
+**Files:**
+- Modify: `apps/fiona-slack/src/listeners/events/app_mention.js`
+- Modify: `apps/fiona-slack/src/listeners/assistant/message.js`
+- Modify: `apps/fiona-slack/tests/listeners/events/app-mention.test.js`
+- Modify: `apps/fiona-slack/tests/listeners/assistant/message.test.js`
+
+- [ ] **Step 1: Write the failing tests for `app_mention.js` capture**
+
+In `apps/fiona-slack/tests/listeners/events/app-mention.test.js`, add `captureConversation` to the mock module factory. Find the existing mock factory block (the `jest.unstable_mockModule('../../src/agent/llm-caller.js', ...)` section) and locate any `jest.unstable_mockModule` near the top. Add a new mock **before** the module is imported:
+
+After all existing `jest.unstable_mockModule` calls, add:
+
+```javascript
+jest.unstable_mockModule('../../src/agent/conversation-capture-store.js', () => ({
+  captureConversation: jest.fn().mockResolvedValue(undefined),
+}));
+```
+
+Then in the `beforeAll` import block (where `callLLM` and others are imported), add:
+
+```javascript
+const { captureConversation } = await import('../../../src/agent/conversation-capture-store.js');
+```
+
+Then add these tests to the test suite (before the final closing `}`):
+
+```javascript
+describe('conversation capture', () => {
+  beforeEach(() => {
+    captureConversation.mockClear();
+    callLLM.mockResolvedValue({
+      metadata: { finalize_state: 'ready_to_finalize', sources: [], source_index_map: {}, provider: 'perplexity' },
+      botText: 'Bot answer here.',
+    });
+  });
+
+  it('calls captureConversation with correct fields after a successful LLM response', async () => {
+    await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
+
+    expect(captureConversation).toHaveBeenCalledTimes(1);
+    const call = captureConversation.mock.calls[0][0];
+    expect(call.userId).toBe(mockEvent.user);
+    expect(call.channelId).toBe(mockEvent.channel);
+    expect(call.entryPoint).toBe('app_mention');
+    expect(call.botResponse).toBe('Bot answer here.');
+    expect(call.llmProvider).toBe('perplexity');
+  });
+
+  it('does not call captureConversation when callLLM throws', async () => {
+    callLLM.mockRejectedValueOnce(new Error('LLM failure'));
+
+    await appMentionCallback({ event: mockEvent, client: mockClient, logger: mockLogger, say: mockSay });
+
+    expect(captureConversation).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the new app_mention capture tests to verify they fail**
+
+```bash
+cd apps/fiona-slack && node --experimental-vm-modules node_modules/.bin/jest tests/listeners/events/app-mention --no-coverage 2>&1 | tail -20
+```
+
+Expected: FAIL — `captureConversation` is never called.
+
+- [ ] **Step 3: Wire capture into `app_mention.js`**
+
+In `apps/fiona-slack/src/listeners/events/app_mention.js`, add the import after the existing imports:
+
+```javascript
+import { captureConversation } from '../../agent/conversation-capture-store.js';
+import { LLM_MODEL } from '../../agent/llm-caller.js';
+```
+
+Then, after `finalizeMetadataEnvelope(metadata);`, add:
+
+```javascript
+      await captureConversation({
+        userId: user,
+        teamId: team,
+        channelId: channel,
+        threadTs: thread_ts,
+        messageTs,
+        entryPoint: 'app_mention',
+        userMessage: text,
+        botResponse: botText,
+        threadHistory: prompts,
+        llmProvider: metadata?.provider ?? 'perplexity',
+        llmModel: LLM_MODEL,
+        sources: metadata?.sources,
+        logger,
+      });
+```
+
+- [ ] **Step 4: Run the app_mention tests to verify they pass**
+
+```bash
+cd apps/fiona-slack && node --experimental-vm-modules node_modules/.bin/jest tests/listeners/events/app-mention --no-coverage 2>&1 | tail -20
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Write the failing tests for `message.js` capture**
+
+In `apps/fiona-slack/tests/listeners/assistant/message.test.js`, add the same `jest.unstable_mockModule` for `conversation-capture-store.js` and import `captureConversation` alongside the other imports. Then add these tests:
+
+```javascript
+describe('conversation capture', () => {
+  beforeEach(() => {
+    captureConversation.mockClear();
+    callLLM.mockResolvedValue({
+      metadata: { finalize_state: 'ready_to_finalize', sources: [], source_index_map: {}, provider: 'perplexity' },
+      botText: 'Bot answer here.',
+    });
+  });
+
+  it('calls captureConversation with correct fields after a successful LLM response', async () => {
+    await messageHandler({
+      client: mockClient,
+      context: mockContext,
+      logger: mockLogger,
+      message: mockMessage,
+      say: mockSay,
+      setStatus: mockSetStatus,
+    });
+
+    expect(captureConversation).toHaveBeenCalledTimes(1);
+    const call = captureConversation.mock.calls[0][0];
+    expect(call.userId).toBe(mockContext.userId);
+    expect(call.channelId).toBe(mockMessage.channel);
+    expect(call.entryPoint).toBe('assistant_message');
+    expect(call.botResponse).toBe('Bot answer here.');
+    expect(call.llmProvider).toBe('perplexity');
+  });
+
+  it('does not call captureConversation when callLLM throws', async () => {
+    callLLM.mockRejectedValueOnce(new Error('LLM failure'));
+
+    await messageHandler({
+      client: mockClient,
+      context: mockContext,
+      logger: mockLogger,
+      message: mockMessage,
+      say: mockSay,
+      setStatus: mockSetStatus,
+    });
+
+    expect(captureConversation).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 6: Run the message tests to verify they fail**
+
+```bash
+cd apps/fiona-slack && node --experimental-vm-modules node_modules/.bin/jest tests/listeners/assistant/message --no-coverage 2>&1 | tail -20
+```
+
+Expected: FAIL — `captureConversation` is never called.
+
+- [ ] **Step 7: Wire capture into `message.js`**
+
+In `apps/fiona-slack/src/listeners/assistant/message.js`, add the imports:
+
+```javascript
+import { captureConversation } from '../../agent/conversation-capture-store.js';
+import { LLM_MODEL } from '../../agent/llm-caller.js';
+```
+
+Inside the `else` branch (normal LLM path), after `finalizeMetadataEnvelope(metadata);`, add:
+
+```javascript
+        await captureConversation({
+          userId,
+          teamId,
+          channelId: channel,
+          threadTs: thread_ts,
+          messageTs,
+          entryPoint: 'assistant_message',
+          userMessage: text,
+          botResponse: botText,
+          threadHistory: prompts,
+          llmProvider: metadata?.provider ?? 'perplexity',
+          llmModel: LLM_MODEL,
+          sources: metadata?.sources,
+          logger,
+        });
+```
+
+- [ ] **Step 8: Run the full test suite**
+
+```bash
+cd apps/fiona-slack && node --experimental-vm-modules node_modules/.bin/jest --no-coverage 2>&1 | tail -20
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/fiona-slack/src/listeners/events/app_mention.js \
+        apps/fiona-slack/src/listeners/assistant/message.js \
+        apps/fiona-slack/tests/listeners/events/app-mention.test.js \
+        apps/fiona-slack/tests/listeners/assistant/message.test.js
+git commit -m "feat(ai-129): wire conversation capture into app_mention and assistant_message handlers"
+```
+
+---
+
+## Task 4: Bicep — provision `conversations` container and env vars
+
+This task adds the Cosmos DB `conversations` container (with 360-day TTL) and the application configuration env vars to the container app.
+
+**Files:**
+- Modify: `infra/fiona-slack-container/main.bicep`
+
+> Note: Bicep changes cannot be unit-tested locally in the same way as JS code. Verify by reviewing the diff for structural correctness and running a deploy to the insiders environment after merging.
+
+- [ ] **Step 1: Add `conversationsContainerName` and `captureAllConversations` parameters**
+
+In `infra/fiona-slack-container/main.bicep`, add after the `interactionsContainerName` parameter:
+
+```bicep
+@description('Cosmos DB container name for full conversation capture')
+param conversationsContainerName string = 'conversations'
+
+@description('Enable capturing all conversations for human evaluation (default: false)')
+param captureAllConversations bool = false
+```
+
+- [ ] **Step 2: Add the `conversations` Cosmos container resource**
+
+Add after the `feedbackContainer` resource block (before the `// --- Container App` comment):
+
+```bicep
+// Conversations Container for human evaluation of full conversation history
+resource conversationsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-05-15' = {
+  name: conversationsContainerName
+  parent: sqlDatabase
+  properties: {
+    resource: {
+      id: conversationsContainerName
+      partitionKey: {
+        paths: [ '/deploymentType', '/userId' ]
+        kind: 'MultiHash'
+        version: 2
+      }
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        includedPaths: [
+          { path: '/*' }
+        ]
+        excludedPaths: [
+          { path: '/"_etag"/?' }
+          // threadHistory and botResponse are large text blobs — exclude from index
+          { path: '/threadHistory/*' }
+          { path: '/botResponse/?' }
+          { path: '/userMessage/?' }
+        ]
+        compositeIndexes: [
+          [
+            { path: '/userId', order: 'ascending' }
+            { path: '/timestamp', order: 'descending' }
+          ]
+          [
+            { path: '/entryPoint', order: 'ascending' }
+            { path: '/timestamp', order: 'descending' }
+          ]
+        ]
+      }
+      // 360-day TTL — documents expire automatically; per-document ttl field overrides if needed
+      defaultTtl: 31104000
+    }
+    options: {}
+  }
+}
+```
+
+- [ ] **Step 3: Add env vars to the container app**
+
+In the `env` array inside the container app `template.containers[0]`, add after the `DEPLOYMENT_TYPE` env var entry:
+
+```bicep
+            {
+              name: 'COSMOS_CONVERSATIONS_CONTAINER'
+              value: conversationsContainerName
+            }
+            {
+              name: 'CAPTURE_ALL_CONVERSATIONS'
+              value: captureAllConversations ? 'true' : 'false'
+            }
+            {
+              name: 'COSMOS_INTERACTIONS_CONTAINER'
+              value: interactionsContainerName
+            }
+```
+
+> Note: `COSMOS_INTERACTIONS_CONTAINER` is referenced in `interaction-store.js` but was not previously wired via Bicep — add it here for consistency while you're touching this section.
+
+- [ ] **Step 4: Add `conversationsContainer` to the container app `dependsOn`**
+
+Find the existing `dependsOn` at the bottom of the `slackContainerApp` resource:
+
+```bicep
+  dependsOn: [
+    acrPullRoleAssignment
+  ]
+```
+
+Replace with:
+
+```bicep
+  dependsOn: [
+    acrPullRoleAssignment
+    conversationsContainer
+  ]
+```
+
+- [ ] **Step 5: Review the Bicep diff**
+
+```bash
+git diff infra/fiona-slack-container/main.bicep
+```
+
+Verify:
+- Two new parameters (`conversationsContainerName`, `captureAllConversations`)
+- One new resource (`conversationsContainer`) with `defaultTtl: 31104000`
+- Two new env vars in the container app (`COSMOS_CONVERSATIONS_CONTAINER`, `CAPTURE_ALL_CONVERSATIONS`)
+- `COSMOS_INTERACTIONS_CONTAINER` env var added
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add infra/fiona-slack-container/main.bicep
+git commit -m "feat(ai-129): provision conversations Cosmos container with 360-day TTL"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Requirement | Covered by |
+|-------------|-----------|
+| All conversations captured when `CAPTURE_ALL_CONVERSATIONS=true` | Task 2 (store), Task 3 (wiring) |
+| Zero overhead when flag is false | Task 2 (early return before any I/O) |
+| Graceful degradation if Cosmos unconfigured | Task 2 (`getContainer` no-op + warn) |
+| 360-day TTL | Task 2 (`CONVERSATION_TTL_SECONDS = 31_104_000`), Task 4 (`defaultTtl: 31104000`) |
+| Independent from feedback/interaction containers | Task 2 (separate singleton, separate env var, separate container) |
+| User message + bot response + full thread history | Task 2 (schema), Task 3 (passed from listeners) |
+| User/channel/workspace IDs | Task 2 (schema), Task 3 |
+| Entry point | Task 2 (schema), Task 3 (`entryPoint: 'app_mention'` / `'assistant_message'`) |
+| LLM provider + model | Task 1 (`LLM_MODEL` export), Task 3 (passed from listeners) |
+| Citations/sources | Task 3 (`sources: metadata?.sources`) |
+| Deployment type | Task 2 (`DEPLOYMENT_TYPE`) |
+| Infrastructure provisioning | Task 4 |
+| Bot response text available | Task 1 (`callLLM` returns `{ metadata, botText }`) |
+
+**Slash command path (AI-119):** Slash commands do not invoke the LLM and are intentionally excluded — there is no bot response to capture. When AI-119 merges, no capture wiring is needed for `/fiona help`.
+
+**Open item:** The Bicep `COSMOS_INTERACTIONS_CONTAINER` env var (Step 4.3) adds something not previously in Bicep. Verify that `interaction-store.js` reads `process.env.COSMOS_INTERACTIONS_CONTAINER` (it does, line 13 of that file) and that the existing deployed container name matches the default `'interactions'` before deploying, to avoid an unintended container name change.

--- a/docs/testing-with-cosmos-emulator.md
+++ b/docs/testing-with-cosmos-emulator.md
@@ -70,4 +70,4 @@ Confirm a document exists containing:
 | `threadHistory` | Array of `{role, content}` objects |
 | `entryPoint` | `app_mention` or `assistant_message` |
 | `deploymentType` | `local` |
-| `ttl` | `31104000` |
+| `ttl` | `15552000` |

--- a/docs/testing-with-cosmos-emulator.md
+++ b/docs/testing-with-cosmos-emulator.md
@@ -46,8 +46,8 @@ npm run setup:emulator
 
 The emulator uses a self-signed TLS certificate, so you must bypass certificate validation:
 
-```bash
-NODE_TLS_REJECT_UNAUTHORIZED=0 slack run
+```pwsh
+$env:NODE_TLS_REJECT_UNAUTHORIZED=0; slack run
 ```
 
 ### 4. Trigger a message

--- a/docs/testing-with-cosmos-emulator.md
+++ b/docs/testing-with-cosmos-emulator.md
@@ -19,4 +19,55 @@ COSMOS_CONNECTION_STRING=AccountEndpoint=https://localhost:8081/;AccountKey=C2y6
 
 ## Create Required Containers
 
-Call `npm run setup:emulator` in the `fiona-slack` app to create the required database and container in the emulator.
+Call `npm run setup:emulator` in the `fiona-slack` app to create the required database and containers in the emulator.
+
+## Smoke Testing Conversation Capture
+
+To verify that the conversation capture feature is working end-to-end:
+
+### 1. Configure your `.env`
+
+In `apps/fiona-slack/.env`, ensure the following are set:
+
+```env
+COSMOS_CONNECTION_STRING=AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTq+JjS9+V0yS;
+CAPTURE_ALL_CONVERSATIONS=true
+DEPLOYMENT_TYPE=local
+```
+
+### 2. Create containers
+
+```bash
+cd apps/fiona-slack
+npm run setup:emulator
+```
+
+### 3. Run the bot
+
+The emulator uses a self-signed TLS certificate, so you must bypass certificate validation:
+
+```bash
+NODE_TLS_REJECT_UNAUTHORIZED=0 slack run
+```
+
+### 4. Trigger a message
+
+Send a message to the bot — either via a DM in App Home or by mentioning `@Fiona` in a channel.
+
+### 5. Verify capture in Data Explorer
+
+Navigate to `https://localhost:8081/_explorer/index.html` and open:
+
+**`fiona` database → `conversations` container → Items**
+
+Confirm a document exists containing:
+
+| Field | Expected |
+|---|---|
+| `userId` | Your Slack user ID |
+| `userMessage` | The message you sent |
+| `botResponse` | Fiona's reply |
+| `threadHistory` | Array of `{role, content}` objects |
+| `entryPoint` | `app_mention` or `assistant_message` |
+| `deploymentType` | `local` |
+| `ttl` | `31104000` |

--- a/docs/usage-report/manual-testing-usage-report.md
+++ b/docs/usage-report/manual-testing-usage-report.md
@@ -60,7 +60,7 @@ COSMOS_CONNECTION_STRING=AccountEndpoint=https://localhost:8081/;AccountKey=C2y6
 
 Also configure the Perplexity API key and Slack app credentials as needed.
 
-Start `fiona-slack` following its README, then confirm it connects to Slack, e.g. `npm run slack:unsafe` or `slack run` depending on your setup.
+Start `fiona-slack` following its README, then confirm it connects to Slack, e.g. in PowerShell run `$env:NODE_TLS_REJECT_UNAUTHORIZED=0; slack run`.
 
 ---
 

--- a/infra/fiona-slack-container/main.bicep
+++ b/infra/fiona-slack-container/main.bicep
@@ -401,6 +401,8 @@ resource slackContainerApp 'Microsoft.App/containerApps@2022-03-01' = {
   dependsOn: [
     acrPullRoleAssignment
     usersContainer
+    interactionsContainer
+    feedbackContainer
     conversationsContainer
   ]
 }

--- a/infra/fiona-slack-container/main.bicep
+++ b/infra/fiona-slack-container/main.bicep
@@ -73,6 +73,12 @@ param interactionsContainerName string = 'interactions'
 @description('Cosmos DB container name for Slack workspace user cache')
 param usersContainerName string = 'slack-users'
 
+@description('Cosmos DB container name for full conversation capture')
+param conversationsContainerName string = 'conversations'
+
+@description('Enable capturing all conversations for human evaluation (default: false)')
+param captureAllConversations bool = false
+
 // --- Reference shared resources ---
 
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = {
@@ -234,6 +240,48 @@ resource usersContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/cont
   }
 }
 
+// Conversations Container for human evaluation of full conversation history
+resource conversationsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-05-15' = {
+  name: conversationsContainerName
+  parent: sqlDatabase
+  properties: {
+    resource: {
+      id: conversationsContainerName
+      partitionKey: {
+        paths: [ '/deploymentType', '/userId' ]
+        kind: 'MultiHash'
+        version: 2
+      }
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        includedPaths: [
+          { path: '/*' }
+        ]
+        excludedPaths: [
+          { path: '/"_etag"/?' }
+          // threadHistory and botResponse are large text blobs — exclude from index
+          { path: '/threadHistory/*' }
+          { path: '/botResponse/?' }
+          { path: '/userMessage/?' }
+        ]
+        compositeIndexes: [
+          [
+            { path: '/userId', order: 'ascending' }
+            { path: '/timestamp', order: 'descending' }
+          ]
+          [
+            { path: '/entryPoint', order: 'ascending' }
+            { path: '/timestamp', order: 'descending' }
+          ]
+        ]
+      }
+      // 360-day TTL — documents expire automatically; per-document ttl field overrides if needed
+      defaultTtl: 31104000
+    }
+    options: {}
+  }
+}
+
 // --- Container App (Socket Mode -- no ingress, fixed 1 replica) ---
 
 resource slackContainerApp 'Microsoft.App/containerApps@2022-03-01' = {
@@ -326,6 +374,18 @@ resource slackContainerApp 'Microsoft.App/containerApps@2022-03-01' = {
               name: 'DEPLOYMENT_TYPE'
               value: deploymentType
             }
+            {
+              name: 'COSMOS_CONVERSATIONS_CONTAINER'
+              value: conversationsContainerName
+            }
+            {
+              name: 'CAPTURE_ALL_CONVERSATIONS'
+              value: captureAllConversations ? 'true' : 'false'
+            }
+            {
+              name: 'COSMOS_INTERACTIONS_CONTAINER'
+              value: interactionsContainerName
+            }
           ]
           // No probes -- no ingress port for HTTP health checks
           // Container restart policy handles crash recovery
@@ -340,6 +400,8 @@ resource slackContainerApp 'Microsoft.App/containerApps@2022-03-01' = {
   }
   dependsOn: [
     acrPullRoleAssignment
+    usersContainer
+    conversationsContainer
   ]
 }
 

--- a/infra/fiona-slack-container/main.bicep
+++ b/infra/fiona-slack-container/main.bicep
@@ -275,8 +275,8 @@ resource conversationsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDataba
           ]
         ]
       }
-      // 360-day TTL — documents expire automatically; per-document ttl field overrides if needed
-      defaultTtl: 31104000
+      // 180-day TTL — documents expire automatically; per-document ttl field overrides if needed
+      defaultTtl: 15552000
     }
     options: {}
   }


### PR DESCRIPTION
## Summary

- Adds `conversation-capture-store.js` — a Cosmos DB store that records full conversation records (user message, bot response, thread history, LLM metadata, citations) behind `CAPTURE_ALL_CONVERSATIONS`.
- Updates `callLLM` to return `{ metadata, botText, systemPromptVersion }` so listeners can persist full response text plus prompt-version metadata.
- Wires `captureConversation` into `app_mention.js` and `assistant/message.js` after successful LLM completion/finalization.
- Provisions a dedicated `conversations` Cosmos container in Bicep and aligns conversation retention to **180 days** (`defaultTtl: 15552000`, app-side `ttl: 15_552_000`).

## Security / Compliance updates in this PR

- Missing-field warning logs in conversation capture now include only missing field names (not raw user/channel/thread/message values).
- Conversation capture rejects `COSMOS_ENDPOINT + COSMOS_KEY` auth in `DEPLOYMENT_TYPE=production` and logs a warning to require connection string or managed identity for production.

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `CAPTURE_ALL_CONVERSATIONS` | `false` | Set to `true` to enable conversation capture |
| `COSMOS_CONVERSATIONS_CONTAINER` | `conversations` | Container name override |
| `SYSTEM_PROMPT_VERSION` | `v1` | Version tag persisted with captured records |

## Test coverage highlights

- Conversation capture retry/reconnect behavior covered (`429` retry, non-retryable no-retry, max-attempt exhaustion, reconnect path on `410`).
- Disabled-flag path covered for both unset and `'false'` values.
- Listener tests updated to verify `systemPromptVersion` propagation into capture payloads.
- `callLLM` return-shape tests updated for `systemPromptVersion`.

## Follow-up scope (tracked separately)

Hardening and refactor follow-up items are tracked in: **#57**